### PR TITLE
TaskConfig is now a property of the TaskExecutor

### DIFF
--- a/examples/async.py
+++ b/examples/async.py
@@ -3,7 +3,6 @@ import logging
 import os
 import time
 
-from task_processing.interfaces.task_executor import TaskConfig
 from task_processing.plugins.mesos.mesos_executor import MesosExecutor
 from task_processing.runners.async import Async
 from task_processing.runners.async import EventHandler
@@ -35,6 +34,7 @@ def main():
         )]
     )
 
+    TaskConfig = MesosExecutor.TASK_CONFIG_INTERFACE
     tasks_to_launch = 2
     for _ in range(tasks_to_launch):
         task_config = TaskConfig(image="busybox",

--- a/task_processing/interfaces/runner.py
+++ b/task_processing/interfaces/runner.py
@@ -2,9 +2,17 @@ import abc
 
 import six
 
+from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
+
 
 @six.add_metaclass(abc.ABCMeta)
 class Runner(object):
+    TASK_CONFIG_INTERFACE = DefaultTaskConfigInterface
+    """
+    The interface, specified as a PRecord of
+    objects that you will be passing as task_configs to run
+    """
+
     @abc.abstractmethod
     def run(self, task_config):
         pass

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -1,9 +1,15 @@
 import logging
 import os
 import threading
+import uuid
 
 import mesos.native
 from mesos.interface import mesos_pb2
+from pyrsistent import field
+from pyrsistent import PRecord
+from pyrsistent import PVector
+from pyrsistent import pvector
+from pyrsistent import v
 
 from task_processing.interfaces.task_executor import TaskExecutor
 from task_processing.plugins.mesos.execution_framework import (
@@ -16,7 +22,34 @@ logging.basicConfig(format=FORMAT, level=LEVEL)
 log = logging.getLogger(__name__)
 
 
+class MesosTaskConfig(PRecord):
+    uuid = field(type=uuid.UUID, initial=uuid.uuid4)
+    name = field(type=str, initial="default")
+    image = field(type=str, initial="ubuntu:xenial")
+    cmd = field(type=str, initial="/bin/true")
+    cpus = field(type=float,
+                 initial=0.1,
+                 invariant=lambda c: (c > 0, 'cpus > 0'))
+    mem = field(type=float,
+                initial=32.0,
+                invariant=lambda m: (m >= 32, 'mem is >= 32'))
+    disk = field(type=float,
+                 initial=10.0,
+                 invariant=lambda d: (d > 0, 'disk > 0'))
+    volumes = field(type=PVector, initial=v(), factory=pvector)
+    ports = field(type=PVector, initial=v(), factory=pvector)
+    cap_add = field(type=PVector, initial=v(), factory=pvector)
+    ulimit = field(type=PVector, initial=v(), factory=pvector)
+    # TODO: containerization + containerization_args ?
+    docker_parameters = field(type=PVector, initial=v(), factory=pvector)
+
+    def task_id(self):
+        return "{}.{}".format(self.name, str(self.uuid))
+
+
 class MesosExecutor(TaskExecutor):
+    TASK_CONFIG_INTERFACE = MesosTaskConfig
+
     def __init__(self,
                  authentication_principal='taskproc',
                  credential_secret_file=None,

--- a/task_processing/runners/async.py
+++ b/task_processing/runners/async.py
@@ -19,6 +19,7 @@ class Async(Runner):
 
         self.callbacks = callbacks
         self.executor = executor
+        self.TASK_CONFIG_INTERFACE = executor.TASK_CONFIG_INTERFACE
         self.stopping = False
 
         callback_t = Thread(target=self.callback_loop)

--- a/task_processing/runners/subscription.py
+++ b/task_processing/runners/subscription.py
@@ -9,6 +9,7 @@ from task_processing.interfaces.runner import Runner
 class Subscription(Runner):
     def __init__(self, executor, queue):
         self.executor = executor
+        self.TASK_CONFIG_INTERFACE = executor.TASK_CONFIG_INTERFACE
         self.event_queue = queue
         self.stopping = False
         self.producer_t = Thread(target=self.event_producer)

--- a/task_processing/runners/sync.py
+++ b/task_processing/runners/sync.py
@@ -9,6 +9,7 @@ from task_processing.interfaces.runner import Runner
 class Sync(Runner):
     def __init__(self, executor):
         self.executor = executor
+        self.TASK_CONFIG_INTERFACE = executor.TASK_CONFIG_INTERFACE
         self.queue = Queue()
 
     def kill(self, *args):


### PR DESCRIPTION
This way each plugin can specify their own interface for tasks. I went with a "has-a" relationship here because I think that will give us the most flexibility when running tasks. 