### PR TITLE
execution framework cleanups

### DIFF
--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -57,7 +57,6 @@ class MesosExecutor(TaskExecutor):
 
         # start driver thread immediately
         self.driver_thread = threading.Thread(target=self.driver.run, args=())
-        self.driver_thread.daemon = True
         self.driver_thread.start()
 
     def run(self, task_config):


### PR DESCRIPTION
- import six.moves.queue
- add execution_framework.stop
- drop start_new_thread