### PR TITLE
add support for uris in task config

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -235,7 +235,11 @@ class ExecutionFramework(Scheduler):
                      ranges=Dict(
                          range=[Dict(begin=port_to_use, end=port_to_use)]))
             ],
-            command=Dict(value=task_config.cmd),
+            command=Dict(
+                value=task_config.cmd,
+                uris=[Dict(value=uri, extract=False)
+                      for uri in task_config.uris]
+            ),
             container=Dict(
                 type='DOCKER',
                 docker=Dict(image=task_config.image,

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -38,6 +38,7 @@ class MesosTaskConfig(PRecord):
     ports = field(type=PVector, initial=v(), factory=pvector)
     cap_add = field(type=PVector, initial=v(), factory=pvector)
     ulimit = field(type=PVector, initial=v(), factory=pvector)
+    uris = field(type=PVector, initial=v(), factory=pvector)
     # TODO: containerization + containerization_args ?
     docker_parameters = field(type=PVector, initial=v(), factory=pvector)
 


### PR DESCRIPTION
internal TASKPROC-25

add support for adding uris to the task config. This is used for pulling in the credentials for the docker registry, but I've kept it generic so that users aren't restricted to using it for only the docker registry.