### PR TITLE
Add support for mesos role in execution framework

### DIFF
--- a/examples/async.py
+++ b/examples/async.py
@@ -22,7 +22,8 @@ def main():
     mesos_address = os.environ['MESOS']
     executor = MesosExecutor(
         credential_secret_file='./examples/cluster/secret',
-        mesos_address=mesos_address
+        mesos_address=mesos_address,
+        role='task-proc'
     )
 
     counter = Counter()

--- a/examples/cluster/docker-compose.yaml
+++ b/examples/cluster/docker-compose.yaml
@@ -22,11 +22,11 @@ services:
       dockerfile: Dockerfile.mesos
     expose:
       - 5051
-    environment:
-      CLUSTER: testcluster
-    command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus(*):10; mem(*):512; disk(*):100" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default" --no-docker_kill_orphans --log_dir=/var/log/mesos'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      CLUSTER: testcluster
+    command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus:20;mem:2048;disk:2000;ports:[31000-31100];cpus(task-proc):10;mem(task-proc):1024;disk(task-proc):1000;ports(task-proc):[31200-31500]" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default" --no-docker_kill_orphans --log_dir=/var/log/mesos'
     depends_on:
       - mesosmaster
       - zookeeper

--- a/examples/promise.py
+++ b/examples/promise.py
@@ -13,8 +13,11 @@ logging.basicConfig()
 def main():
     credentials = {'principal': 'mesos', 'secret': 'very'}
     mesos_address = os.environ['MESOS']
-    executor = MesosExecutor(credentials=credentials,
-                             mesos_address=mesos_address)
+    executor = MesosExecutor(
+        credentials=credentials,
+        mesos_address=mesos_address,
+        role='task-proc'
+    )
     task_config = make_task_config(image="ubuntu:14.04", cmd="/bin/sleep 10")
     runner = Promise(executor)
     future = runner.run(task_config)

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -15,7 +15,8 @@ def main():
     mesos_address = os.environ['MESOS']
     executor = MesosExecutor(
         credential_secret_file='./examples/cluster/secret',
-        mesos_address=mesos_address
+        mesos_address=mesos_address,
+        role='task-proc'
     )
 
     queue = Queue(100)

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -12,7 +12,8 @@ def main():
     mesos_address = os.environ.get('MESOS', '127.0.0.1:5050')
     executor = MesosExecutor(
         credential_secret_file='./examples/cluster/secret',
-        mesos_address=mesos_address
+        mesos_address=mesos_address,
+        role='task-proc'
     )
 
     TaskConfig = MesosExecutor.TASK_CONFIG_INTERFACE

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -29,6 +29,7 @@ class ExecutionFramework(Scheduler):
     def __init__(
         self,
         name,
+        role,
         task_staging_timeout_s=240,
         pool=None,
         max_task_queue_size=1000,
@@ -41,6 +42,7 @@ class ExecutionFramework(Scheduler):
         # wait this long for a task to launch.
         self.task_staging_timeout_s = task_staging_timeout_s
         self.pool = pool
+        self.role = role
         self.translator = translator
         self.slave_blacklist_timeout_s = slave_blacklist_timeout_s
         self.offer_backoff = offer_backoff
@@ -48,7 +50,11 @@ class ExecutionFramework(Scheduler):
 
         # TODO: why does this need to be root, can it be "mesos plz figure out"
         self.framework_info = Dict(
-            user='root', name=self.name, checkpoint=True)
+            user='root',
+            name=self.name,
+            checkpoint=True,
+            role=self.role
+        )
         self.task_queue = Queue(max_task_queue_size)
         self.task_update_queue = Queue(max_task_queue_size)
         self.driver = None
@@ -153,23 +159,24 @@ class ExecutionFramework(Scheduler):
         remaining_disk = 0
         available_ports = []
         for resource in offer.resources:
-            if resource.name == "cpus":
+            if resource.name == "cpus" and resource.role == self.role:
                 remaining_cpus += resource.scalar.value
-            elif resource.name == "mem":
+            elif resource.name == "mem" and resource.role == self.role:
                 remaining_mem += resource.scalar.value
-            elif resource.name == "disk":
+            elif resource.name == "disk" and resource.role == self.role:
                 remaining_disk += resource.scalar.value
-            elif resource.name == "ports":
+            elif resource.name == "ports" and resource.role == self.role:
                 # TODO: Validate if the ports available > ports required
                 available_ports = self.get_available_ports(resource)
 
         log.info(
-            "Received offer {id} with cpus: {cpu}, mem: {mem}, \
-            disk: {disk}".format(
+            'Received offer {id} with cpus: {cpu}, mem: {mem},\
+            disk: {disk} role: {role}'.format(
                 id=offer.id.value,
                 cpu=remaining_cpus,
                 mem=remaining_mem,
-                disk=remaining_disk
+                disk=remaining_disk,
+                role=self.role
             )
         )
 
@@ -210,6 +217,7 @@ class ExecutionFramework(Scheduler):
     def create_new_docker_task(self, offer, task_config, available_ports):
         # Handle the case of multiple port allocations
         port_to_use = available_ports[0]
+        available_ports[:] = available_ports[1:]
 
         md = self.task_metadata[task_config.task_id]
         self.task_metadata[task_config.task_id] = md.set(
@@ -223,15 +231,19 @@ class ExecutionFramework(Scheduler):
             resources=[
                 Dict(name='cpus',
                      type='SCALAR',
+                     role=self.role,
                      scalar=Dict(value=task_config.cpus)),
                 Dict(name='mem',
                      type='SCALAR',
+                     role=self.role,
                      scalar=Dict(value=task_config.mem)),
                 Dict(name='disk',
                      type='SCALAR',
+                     role=self.role,
                      scalar=Dict(value=task_config.disk)),
                 Dict(name='ports',
                      type='RANGES',
+                     role=self.role,
                      ranges=Dict(
                          range=[Dict(begin=port_to_use, end=port_to_use)]))
             ],
@@ -263,13 +275,15 @@ class ExecutionFramework(Scheduler):
     def registered(self, driver, frameworkId, masterInfo):
         if self.driver is None:
             self.driver = driver
-        log.info("Registered with framework ID {id}".format(
-            id=frameworkId.value
+        log.info("Registered with framework ID {id} and role {role}".format(
+            id=frameworkId.value,
+            role=self.role
         ))
 
     def reregistered(self, driver, frameworkId, masterInfo):
-        log.warning("Registered with framework ID {id}".format(
-            id=frameworkId.value
+        log.warning("Registered with framework ID {id} and role {role}".format(
+            id=frameworkId.value,
+            role=self.role
         ))
 
     def resourceOffers(self, driver, offers):

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -49,11 +49,14 @@ class MesosTaskConfig(PRecord):
 class MesosExecutor(TaskExecutor):
     TASK_CONFIG_INTERFACE = MesosTaskConfig
 
-    def __init__(self,
-                 authentication_principal='taskproc',
-                 credential_secret_file=None,
-                 mesos_address='127.0.0.1:5050',
-                 translator=mesos_status_to_event):
+    def __init__(
+        self,
+        role,
+        authentication_principal='taskproc',
+        credential_secret_file=None,
+        mesos_address='127.0.0.1:5050',
+        translator=mesos_status_to_event,
+    ):
         """
         Constructs the instance of a task execution, encapsulating all state
         required to run, monitor and stop the job.
@@ -73,6 +76,7 @@ class MesosExecutor(TaskExecutor):
             name="test",
             task_staging_timeout_s=60,
             translator=translator,
+            role=role
         )
 
         # TODO: Get mesos master ips from smartstack

--- a/tests/integration/mesos/mesos_test.py
+++ b/tests/integration/mesos/mesos_test.py
@@ -8,7 +8,7 @@ from task_processing.runners.sync import Sync
 
 @given('mesos executor with {runner} runner')
 def mesos_executor_runner(runner):
-    executor = MesosExecutor()
+    executor = MesosExecutor(role='mock-role')
 
     if runner == 'sync':
         runner_instance = Sync(executor=executor)


### PR DESCRIPTION
How does this work?
All the frameworks must use a role while registering with mesos. The framework will only use resources that belong to their role. Mesos will offer them resources with role * and their own role.

How do I know it works?
Ran all the examples and `make test`