### PR TITLE
Kawaiwan make thread safe

### DIFF
--- a/examples/async.py
+++ b/examples/async.py
@@ -20,8 +20,10 @@ class Counter(object):
 
 def main():
     mesos_address = os.environ['MESOS']
+    with open('./examples/cluster/secret') as f:
+        secret = f.read().strip()
     executor = MesosExecutor(
-        credential_secret_file='./examples/cluster/secret',
+        secret=secret,
         mesos_address=mesos_address,
         role='task-proc'
     )

--- a/examples/async.py
+++ b/examples/async.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 import os
 import time

--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:trusty
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         debhelper dpkg-dev gcc gdebi-core git help2man libffi-dev \
-        libssl-dev libsasl2-modules libyaml-dev pyflakes python-dev python-pip python-pytest \
-        python-setuptools python-tox python-yaml wget zip zsh \
+        libssl-dev libsasl2-modules libyaml-dev pyflakes python3-dev python3-pip python3-pytest \
+        python3-setuptools python-tox python-yaml wget zip zsh \
         openssh-server docker.io curl vim jq libsvn-dev \
     && apt-get clean
 
@@ -16,12 +16,11 @@ RUN cd /tmp && \
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN mkdir /var/run/sshd
 
-RUN pip install --upgrade pip==9.0.1
-RUN pip install --upgrade virtualenv==15.1.0
+RUN pip3 install --upgrade pip==9.0.1
+RUN pip3 install --upgrade virtualenv==15.1.0
 
 # FIXME use actual virtualenv
-RUN pip install pymesos
-RUN pip install pyrsistent
+RUN pip3 install pymesos pyrsistent
 
 ADD . /src
 ENV PYTHONPATH=/src

--- a/examples/file_persistence.py
+++ b/examples/file_persistence.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import logging
+import os
+
+from task_processing.executors.stateful.stateful_executor \
+    import StatefulTaskExecutor
+from task_processing.plugins.mesos.mesos_executor import MesosExecutor
+from task_processing.plugins.persistence.file_persistence \
+    import FilePersistence
+from task_processing.runners.sync import Sync
+
+logging.basicConfig()
+
+
+def main():
+    mesos_address = os.getenv('MESOS', 'mesosmaster:5050')
+    mesos_executor = MesosExecutor(
+        credential_secret_file='./examples/cluster/secret',
+        mesos_address=mesos_address,
+        role='task-proc'
+    )
+    executor = StatefulTaskExecutor(
+        downstream_executor=mesos_executor,
+        persister=FilePersistence(
+            output_file='foo'
+        )
+    )
+    runner = Sync(executor=executor)
+    tasks = set()
+    TaskConfig = MesosExecutor.TASK_CONFIG_INTERFACE
+    for _ in range(1, 2):
+        task_config = TaskConfig(
+            image='ubuntu:14.04', cmd='/bin/sleep 2'
+        )
+        tasks.add(task_config.task_id)
+        runner.run(task_config)
+        print(executor.status(task_config.task_id))
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/examples/promise.py
+++ b/examples/promise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 import os
 

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 import os
 

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -13,8 +13,10 @@ logging.basicConfig()
 
 def main():
     mesos_address = os.environ['MESOS']
+    with open('./examples/cluster/secret') as f:
+        secret = f.read().strip()
     executor = MesosExecutor(
-        credential_secret_file='./examples/cluster/secret',
+        secret=secret,
         mesos_address=mesos_address,
         role='task-proc'
     )

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import logging
 import os
 

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -10,8 +10,10 @@ logging.basicConfig()
 
 def main():
     mesos_address = os.environ.get('MESOS', '127.0.0.1:5050')
+    with open('./examples/cluster/secret') as f:
+        secret = f.read().strip()
     executor = MesosExecutor(
-        credential_secret_file='./examples/cluster/secret',
+        secret=secret,
         mesos_address=mesos_address,
         role='task-proc'
     )

--- a/itest
+++ b/itest
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eux
+
+examples/file_persistence.py
+#examples/sync.py
+#examples/async.py
+#examples/subscription.py

--- a/task_processing/executors/stateful/stateful_executor.py
+++ b/task_processing/executors/stateful/stateful_executor.py
@@ -1,0 +1,43 @@
+import threading
+
+from six.moves.queue import Queue
+
+from task_processing.interfaces.task_executor import TaskExecutor
+
+
+class StatefulTaskExecutor(TaskExecutor):
+    """
+    """
+
+    def __init__(self, downstream_executor, persister):
+        self.downstream_executor = downstream_executor
+        self.writer_queue = Queue()
+        self.queue_for_processed_events = Queue()
+        self.persister = persister
+        worker_thread = threading.Thread(
+            target=self.subscribe_to_updates_for_task
+        )
+        worker_thread.daemon = True
+        worker_thread.start()
+
+    def run(self, task_config):
+        self.downstream_executor.run(task_config)
+
+    def kill(self, task_id):
+        return self.downstream_executor.kill(task_id)
+
+    def status(self, task_id):
+        return sorted(self.persister.read(task_id), key=lambda x: x.timestamp)
+
+    def stop(self):
+        return self.downstream_executor.stop()
+
+    def get_event_queue(self):
+        return self.queue_for_processed_events
+
+    def subscribe_to_updates_for_task(self):
+        while True:
+            result = self.downstream_executor.get_event_queue().get()
+            self.persister.write(event=result)
+            self.queue_for_processed_events.put(result)
+            self.downstream_executor.get_event_queue().task_done()

--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -1,7 +1,7 @@
 from pyrsistent import field
+from pyrsistent import m
+from pyrsistent import PMap
 from pyrsistent import PRecord
-
-# TODO: organize and explain these
 
 
 class Event(PRecord):
@@ -9,7 +9,10 @@ class Event(PRecord):
     raw = field()
     # is this the last event for a task?
     terminal = field(type=bool, mandatory=True)
+    success = field(type=(bool, type(None)), initial=None)
     # platform-specific event name
     platform_type = field(type=str)
     # task_id this event pertains to
     task_id = field(type=str)
+    task_config = field(type=PRecord)
+    extensions = field(type=PMap, initial=m())

--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -1,10 +1,14 @@
+import datetime
+
 from pyrsistent import field
+from pyrsistent import freeze
 from pyrsistent import m
 from pyrsistent import PMap
 from pyrsistent import PRecord
 
 
 class Event(PRecord):
+    timestamp = field(type=datetime.datetime)
     # reference to platform-specific event object
     raw = field()
     # is this the last event for a task?
@@ -14,5 +18,22 @@ class Event(PRecord):
     platform_type = field(type=str)
     # task_id this event pertains to
     task_id = field(type=str)
-    task_config = field(type=PRecord)
+    task_config = field()
     extensions = field(type=PMap, initial=m())
+
+
+def json_serializer(o):
+    if isinstance(o, datetime.datetime):
+        return o.strftime('%s')
+
+
+def json_deserializer(dct):
+    for k, v in dct.items():
+        if k == 'timestamp':
+            try:
+                dct[k] = datetime.datetime.fromtimestamp(float(v))
+            except:
+                pass
+        else:
+            dct[k] = freeze(v)
+    return dct

--- a/task_processing/interfaces/persistence.py
+++ b/task_processing/interfaces/persistence.py
@@ -1,0 +1,15 @@
+import abc
+
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Persister():
+
+    @abc.abstractmethod
+    def read(self, task_id):
+        pass
+
+    @abc.abstractmethod
+    def write(self, event):
+        pass

--- a/task_processing/interfaces/task_executor.py
+++ b/task_processing/interfaces/task_executor.py
@@ -54,8 +54,6 @@ class TaskExecutor(object):
     def get_event_queue(self):
         """Get queue of events
 
-        :param str task_id: The task that you want to get status on
-
         :returns: TBD
         """
         pass

--- a/task_processing/interfaces/task_executor.py
+++ b/task_processing/interfaces/task_executor.py
@@ -45,8 +45,14 @@ class TaskExecutor(object):
         pass
 
     @abc.abstractmethod
-    def status(self, task_id):
-        """Get Status of the specified task
+    def stop(self):
+        """Stop the executor stack
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_event_queue(self):
+        """Get queue of events
 
         :param str task_id: The task that you want to get status on
 

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -5,6 +5,7 @@ import time
 from addict import Dict
 from pymesos.interface import Scheduler
 from pyrsistent import field
+from pyrsistent import m
 from pyrsistent import PRecord
 from six.moves.queue import Queue
 
@@ -63,8 +64,8 @@ class ExecutionFramework(Scheduler):
 
         self.offer_decline_filter = Dict(refuse_seconds=self.offer_backoff)
         self._lock = threading.RLock()
-        self.blacklisted_slaves = {}
-        self.task_metadata = {}
+        self.blacklisted_slaves = m()
+        self.task_metadata = m()
 
         self.stopping = False
         task_kill_thread = threading.Thread(
@@ -113,13 +114,15 @@ class ExecutionFramework(Scheduler):
         with self._lock:
             if agent_id in self.blacklisted_slaves:
                 # Punish this slave for more time.
-                self.blacklisted_slaves.pop(agent_id, None)
+                self.blacklisted_slaves = \
+                    self.blacklisted_slaves.discard(agent_id)
 
             log.info('Blacklisting slave: {id} for {secs} seconds.'.format(
                 id=agent_id,
                 secs=self.slave_blacklist_timeout_s
             ))
-            self.blacklisted_slaves[agent_id] = time.time()
+            self.blacklisted_slaves = \
+                self.blacklisted_slaves.set(agent_id, time.time())
 
     def unblacklist_slaves(self):
         while True:
@@ -136,14 +139,18 @@ class ExecutionFramework(Scheduler):
                         log.info(
                             'Unblacklisting slave: {id}'.format(id=agent_id)
                         )
-                        self.blacklisted_slaves.pop(agent_id, None)
+                        self.blacklisted_slaves = \
+                            self.blacklisted_slaves.discard(agent_id)
             time.sleep(10)
 
     def enqueue_task(self, task_config):
         with self._lock:
-            self.task_metadata[task_config.task_id] = TaskMetadata(
-                task_config=task_config,
-                time_launched=time.time(),
+            self.task_metadata = self.task_metadata.set(
+                task_config.task_id,
+                TaskMetadata(
+                    task_config=task_config,
+                    time_launched=time.time(),
+                )
             )
 
         self.task_queue.put(task_config)
@@ -240,8 +247,9 @@ class ExecutionFramework(Scheduler):
 
         with self._lock:
             md = self.task_metadata[task_config.task_id]
-            self.task_metadata[task_config.task_id] = md.set(
-                agent_id=str(offer.agent_id.value)
+            self.task_metadata = self.task_metadata.set(
+                task_config.task_id,
+                md.set(agent_id=str(offer.agent_id.value))
             )
 
         return Dict(
@@ -370,10 +378,13 @@ class ExecutionFramework(Scheduler):
             with self._lock:
                 for task in tasks_to_launch:
                     md = self.task_metadata[task.task_id.value]
-                    self.task_metadata[task.task_id.value] = md.set(
-                        retries=md.retries + 1,
-                        time_launched=time.time(),
-                        task_state='launched'
+                    self.task_metadata = self.task_metadata.set(
+                        task.task_id.value,
+                        md.set(
+                            retries=md.retries + 1,
+                            time_launched=time.time(),
+                            task_state='launched'
+                        )
                     )
 
     def statusUpdate(self, driver, update):
@@ -390,7 +401,7 @@ class ExecutionFramework(Scheduler):
 
         if update.state == 'TASK_FINISHED':
             with self._lock:
-                self.task_metadata.pop(task_id, None)
+                self.task_metadata = self.task_metadata.discard(task_id)
 
         if update.state in (
             'TASK_LOST',

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -62,7 +62,7 @@ class ExecutionFramework(Scheduler):
         self.suppress_after = int(time.time()) + self.suppress_delay
 
         self.offer_decline_filter = Dict(refuse_seconds=self.offer_backoff)
-        # TODO: These should be thread safe
+        self._lock = threading.RLock()
         self.blacklisted_slaves = {}
         self.task_metadata = {}
 
@@ -81,17 +81,20 @@ class ExecutionFramework(Scheduler):
             if self.stopping:
                 return
 
-            time_now = time.time()
-            for task_id in self.task_metadata.keys():
-                if time_now > (
-                    self.task_metadata[task_id].time_launched +
-                    self.task_staging_timeout_s
-                ):
-                    log.warning('Killing stuck task {id}'.format(id=task_id))
-                    self.kill_task(task_id)
-                    self.blacklist_slave(
-                        self.task_metadata[task_id].agent_id
-                    )
+            with self._lock:
+                time_now = time.time()
+                for task_id in self.task_metadata.keys():
+                    if time_now > (
+                        self.task_metadata[task_id].time_launched +
+                        self.task_staging_timeout_s
+                    ):
+                        log.warning(
+                            'Killing stuck task {id}'.format(id=task_id)
+                        )
+                        self.kill_task(task_id)
+                        self.blacklist_slave(
+                            self.task_metadata[task_id].agent_id
+                        )
             time.sleep(10)
 
     def offer_matches_pool(self, offer):
@@ -107,37 +110,44 @@ class ExecutionFramework(Scheduler):
         self.driver.killTask(Dict(value=task_id))
 
     def blacklist_slave(self, agent_id):
-        if agent_id in self.blacklisted_slaves:
-            # Punish this slave for more time.
-            self.blacklisted_slaves.pop(agent_id, None)
+        with self._lock:
+            if agent_id in self.blacklisted_slaves:
+                # Punish this slave for more time.
+                self.blacklisted_slaves.pop(agent_id, None)
 
-        log.info('Blacklisting slave: {id} for {secs} seconds.'.format(
-            id=agent_id,
-            secs=self.slave_blacklist_timeout_s
-        ))
-        self.blacklisted_slaves[agent_id] = time.time()
+            log.info('Blacklisting slave: {id} for {secs} seconds.'.format(
+                id=agent_id,
+                secs=self.slave_blacklist_timeout_s
+            ))
+            self.blacklisted_slaves[agent_id] = time.time()
 
     def unblacklist_slaves(self):
         while True:
             if self.stopping:
                 return
 
-            time_now = time.time()
-            for agent_id in self.blacklisted_slaves.keys():
-                if time_now < (
-                    self.blacklisted_slaves[agent_id] +
-                    self.slave_blacklist_timeout_s
-                ):
-                    log.info('Unblacklisting slave: {id}'.format(id=agent_id))
-                    self.blacklisted_slaves.pop(agent_id, None)
+            with self._lock:
+                time_now = time.time()
+                for agent_id in self.blacklisted_slaves.keys():
+                    if time_now < (
+                        self.blacklisted_slaves[agent_id] +
+                        self.slave_blacklist_timeout_s
+                    ):
+                        log.info(
+                            'Unblacklisting slave: {id}'.format(id=agent_id)
+                        )
+                        self.blacklisted_slaves.pop(agent_id, None)
             time.sleep(10)
 
     def enqueue_task(self, task_config):
-        self.task_metadata[task_config.task_id] = TaskMetadata(
-            task_config=task_config,
-            time_launched=time.time(),
-        )
+        with self._lock:
+            self.task_metadata[task_config.task_id] = TaskMetadata(
+                task_config=task_config,
+                time_launched=time.time(),
+            )
+
         self.task_queue.put(task_config)
+
         if self.are_offers_suppressed:
             self.driver.reviveOffers()
             self.are_offers_suppressed = False
@@ -186,31 +196,35 @@ class ExecutionFramework(Scheduler):
         )
 
         tasks_to_put_back_in_queue = []
-        # Get all the tasks of the queue
-        while not self.task_queue.empty():
-            task = self.task_queue.get()
 
-            if ((remaining_cpus >= task.cpus and
-                 remaining_mem >= task.mem and
-                 remaining_disk >= task.disk)):
-                # This offer is sufficient for us to launch task
-                tasks_to_launch.append(
-                    self.create_new_docker_task(
-                        offer,
-                        task,
-                        available_ports
+        # Need to lock here even though we working on the task_queue, because
+        # we are predicating on the queues emptiness
+        with self._lock:
+            # Get all the tasks of the queue
+            while not self.task_queue.empty():
+                task = self.task_queue.get()
+
+                if ((remaining_cpus >= task.cpus and
+                     remaining_mem >= task.mem and
+                     remaining_disk >= task.disk)):
+                    # This offer is sufficient for us to launch task
+                    tasks_to_launch.append(
+                        self.create_new_docker_task(
+                            offer,
+                            task,
+                            available_ports
+                        )
                     )
-                )
 
-                # Deduct the resources taken by this task from the total
-                # available resources.
-                remaining_cpus -= task.cpus
-                remaining_mem -= task.mem
-                remaining_disk -= task.disk
-            else:
-                # This offer is insufficient for this task. We need to put it
-                # back in the queue
-                tasks_to_put_back_in_queue.append(task)
+                    # Deduct the resources taken by this task from the total
+                    # available resources.
+                    remaining_cpus -= task.cpus
+                    remaining_mem -= task.mem
+                    remaining_disk -= task.disk
+                else:
+                    # This offer is insufficient for this task. We need to put
+                    # it back in the queue
+                    tasks_to_put_back_in_queue.append(task)
 
         # TODO: This needs to be thread safe. We can write a wrapper over queue
         # with a mutex.
@@ -224,10 +238,11 @@ class ExecutionFramework(Scheduler):
         port_to_use = available_ports[0]
         available_ports[:] = available_ports[1:]
 
-        md = self.task_metadata[task_config.task_id]
-        self.task_metadata[task_config.task_id] = md.set(
-            agent_id=str(offer.agent_id.value)
-        )
+        with self._lock:
+            md = self.task_metadata[task_config.task_id]
+            self.task_metadata[task_config.task_id] = md.set(
+                agent_id=str(offer.agent_id.value)
+            )
 
         return Dict(
             task_id=Dict(value=task_config.task_id),
@@ -315,14 +330,15 @@ class ExecutionFramework(Scheduler):
             return
 
         for offer in offers:
-            if offer.agent_id.value in self.blacklisted_slaves:
-                log.critical("Ignoring offer {offer_id} from blacklisted \
-                    slave {slave_name}".format(
-                    offer_id=offer.id.value,
-                    slave_name=offer.agent_id.value
-                ))
-                driver.declineOffer(offer.id, self.offer_decline_filter)
-                continue
+            with self._lock:
+                if offer.agent_id.value in self.blacklisted_slaves:
+                    log.critical("Ignoring offer {offer_id} from blacklisted \
+                        slave {slave_name}".format(
+                        offer_id=offer.id.value,
+                        slave_name=offer.agent_id.value
+                    ))
+                    driver.declineOffer(offer.id, self.offer_decline_filter)
+                    continue
 
             if not self.offer_matches_pool(offer):
                 log.info("Declining offer {id} because it is not for pool \
@@ -351,13 +367,14 @@ class ExecutionFramework(Scheduler):
             ))
             driver.launchTasks(offer.id, tasks_to_launch)
 
-            for task in tasks_to_launch:
-                md = self.task_metadata[task.task_id.value]
-                self.task_metadata[task.task_id.value] = md.set(
-                    retries=md.retries + 1,
-                    time_launched=time.time(),
-                    task_state='launched'
-                )
+            with self._lock:
+                for task in tasks_to_launch:
+                    md = self.task_metadata[task.task_id.value]
+                    self.task_metadata[task.task_id.value] = md.set(
+                        retries=md.retries + 1,
+                        time_launched=time.time(),
+                        task_state='launched'
+                    )
 
     def statusUpdate(self, driver, update):
         task_id = update.task_id.value
@@ -372,7 +389,8 @@ class ExecutionFramework(Scheduler):
         )
 
         if update.state == 'TASK_FINISHED':
-            self.task_metadata.pop(task_id, None)
+            with self._lock:
+                self.task_metadata.pop(task_id, None)
 
         if update.state in (
             'TASK_LOST',
@@ -381,7 +399,8 @@ class ExecutionFramework(Scheduler):
             'TASK_ERROR'
         ):
             self.task_update_queue.put(self.translator(update, task_id))
-            self.task_metadata.pop(task_id, None)
+            with self._lock:
+                self.task_metadata = self.task_metadata.discard(task_id)
 
         # We have to do this because we are not using implicit
         # acknowledgements.

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -361,7 +361,10 @@ class ExecutionFramework(Scheduler):
             task=task_id
         ))
 
-        self.task_update_queue.put(self.translator(update, task_id))
+        md = self.task_metadata[task_id]
+        self.task_update_queue.put(
+            self.translator(update, task_id).set(task_config=md.task_config)
+        )
 
         if update.state == 'TASK_FINISHED':
             self.task_metadata.pop(task_id, None)
@@ -373,7 +376,6 @@ class ExecutionFramework(Scheduler):
             'TASK_FAILED',
             'TASK_ERROR'
         ):
-            md = self.task_metadata[task_id]
             if md.retries >= self.task_retries:
                 log.info(
                     'All the retries for task {task} are done.'.format(

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -152,7 +152,7 @@ class ExecutionFramework(Scheduler):
                     time_launched=time.time(),
                 )
             )
-            # Need to lock on task_queue to revent enqueues when getting
+            # Need to lock on task_queue to prevent enqueues when getting
             # tasks to launch
             self.task_queue.put(task_config)
 
@@ -205,9 +205,9 @@ class ExecutionFramework(Scheduler):
 
         tasks_to_put_back_in_queue = []
 
-        # Need to lock here even though we working on the task_queue, because
-        # we are predicating on the queues emptiness. If not, other threads
-        # can continue enqueueing, and we never terminate the loop.
+        # Need to lock here even though we are working on the task_queue, since
+        # we are predicating on the queue's emptiness. If not locked, other
+        # threads can continue enqueueing, and we never terminate the loop.
         with self._lock:
             # Get all the tasks of the queue
             while not self.task_queue.empty():

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -66,10 +66,14 @@ class ExecutionFramework(Scheduler):
         self.task_metadata = {}
 
         self.stopping = False
-        threading.Thread(
-            target=self.kill_tasks_stuck_in_staging, args=()).start()
-        threading.Thread(
-            target=self.unblacklist_slaves, args=()).start()
+        task_kill_thread = threading.Thread(
+            target=self.kill_tasks_stuck_in_staging, args=())
+        task_kill_thread.daemon = True
+        task_kill_thread.start()
+        blacklist_thread = threading.Thread(
+            target=self.unblacklist_slaves, args=())
+        blacklist_thread.daemon = True
+        blacklist_thread.start()
 
     def kill_tasks_stuck_in_staging(self):
         while True:

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -53,10 +53,12 @@ class MesosExecutor(TaskExecutor):
     def __init__(
         self,
         role,
-        authentication_principal='taskproc',
-        credential_secret_file=None,
+        principal='taskproc',
+        secret=None,
         mesos_address='127.0.0.1:5050',
-        translator=mesos_status_to_event,
+        framework_translator=mesos_status_to_event,
+        framework_name='taskproc-default',
+        framework_staging_timeout=60,
     ):
         """
         Constructs the instance of a task execution, encapsulating all state
@@ -67,17 +69,11 @@ class MesosExecutor(TaskExecutor):
 
         self.logger = logging.getLogger(__name__)
 
-        principal = authentication_principal
-        secret = None
-        if credential_secret_file:
-            with open(credential_secret_file) as f:
-                secret = f.read().strip()
-
         self.execution_framework = ExecutionFramework(
-            name="test",
-            task_staging_timeout_s=60,
-            translator=translator,
-            role=role
+            role=role,
+            name=framework_name,
+            translator=framework_translator,
+            task_staging_timeout_s=framework_staging_timeout
         )
 
         # TODO: Get mesos master ips from smartstack

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -92,7 +92,9 @@ class MesosExecutor(TaskExecutor):
         )
 
         # start driver thread immediately
-        self.driver_thread = threading.Thread(target=self.driver.run, args=())
+        self.driver_thread = threading.Thread(
+            target=self.driver.run, args=())
+        self.driver_thread.daemon = True
         self.driver_thread.start()
 
     def run(self, task_config):

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -106,8 +106,5 @@ class MesosExecutor(TaskExecutor):
         self.driver.stop()
         self.driver.join()
 
-    def status(self):
-        pass
-
     def get_event_queue(self):
         return self.execution_framework.task_update_queue

--- a/task_processing/plugins/mesos/retrying_executor.py
+++ b/task_processing/plugins/mesos/retrying_executor.py
@@ -1,0 +1,61 @@
+import time
+from threading import Thread
+
+from pyrsistent import m
+from six.moves.queue import Queue
+
+from task_processing.interfaces.task_executor import TaskExecutor
+
+
+class RetryingExecutor(TaskExecutor):
+    def __init__(self,
+                 executor,
+                 retry_pred=lambda e: not e.success,
+                 retries=3):
+        self.executor = executor
+        self.retries = retries
+        self.retry_pred = retry_pred
+        self.task_retries = m()
+        self.src_queue = executor.get_event_queue()
+        self.dest_queue = Queue()
+        self.retry_thread = Thread(target=self.retry_loop)
+        self.retry_thread.start()
+        self.stopping = False
+        self.TASK_CONFIG_INTERFACE = executor.TASK_CONFIG_INTERFACE
+
+    def retry_loop(self):
+        while True:
+            while not self.src_queue.empty():
+                e = self.src_queue.get()
+                if e.terminal and self.retry_pred(e):
+                    if self.task_retries[e.task_id] > 0:
+                        self.run(e.task_config)
+                        self.task_retries = self.task_retries.set(
+                            e.task_id, self.task_retries[e.task_id] - 1)
+                        continue
+                et = e.transform(
+                    ('extensions', 'retrying'),
+                    self.retries - self.task_retries[e.task_id])
+                self.dest_queue.put(et)
+
+            if self.stopping:
+                return
+
+            time.sleep(1)
+
+    def run(self, task_config):
+        self.tasks_retries[task_config.task_id] = self.retries
+        self.executor.run(task_config)
+
+    def kill(self, task_id):
+        # retries = -1 so that manually killed tasks can be distinguished
+        self.tasks_retries = self.task_retries.set(task_id, -1)
+        self.executor.kill(task_id)
+
+    def stop(self):
+        self.executor.stop()
+        self.stopping = True
+        self.retry_thread.join()
+
+    def get_event_queue(self):
+        return self.dest_queue

--- a/task_processing/plugins/mesos/translator.py
+++ b/task_processing/plugins/mesos/translator.py
@@ -1,3 +1,5 @@
+import datetime
+
 from task_processing.interfaces.event import Event
 
 # https://github.com/apache/mesos/blob/master/include/mesos/mesos.proto
@@ -27,5 +29,6 @@ MESOS_TASK_STATUS_TO_EVENT = {
 def mesos_status_to_event(mesos_status, task_id):
     return MESOS_TASK_STATUS_TO_EVENT[mesos_status.state].set(
         raw=mesos_status,
-        task_id=str(task_id)
+        task_id=str(task_id),
+        timestamp=datetime.datetime.now(),
     )

--- a/task_processing/plugins/persistence/file_persistence.py
+++ b/task_processing/plugins/persistence/file_persistence.py
@@ -1,0 +1,28 @@
+import json
+
+from pyrsistent import thaw
+from pyrsistent import v
+
+from task_processing.interfaces.event import Event
+from task_processing.interfaces.event import json_deserializer
+from task_processing.interfaces.event import json_serializer
+from task_processing.interfaces.persistence import Persister
+
+
+class FilePersistence(Persister):
+    def __init__(self, output_file):
+        self.output_file = output_file
+
+    def read(self, task_id):
+        acc = v()
+        with open(self.output_file, 'r') as f:
+            for line in f:
+                parsed = json.loads(line, object_hook=json_deserializer)
+                if parsed['task_id'] == task_id:
+                    acc = acc.append(Event.create(parsed))
+        return acc
+
+    def write(self, event):
+        with open(self.output_file, 'a+') as f:
+            f.write("{}\n".format(json.dumps(
+                thaw(event), default=json_serializer)))

--- a/tests/mock_plugin/__init__.py
+++ b/tests/mock_plugin/__init__.py
@@ -11,12 +11,25 @@ class DummyTaskExecutor(TaskExecutor):
     def kill(self, task_id):
         pass
 
-    def status(self, task_id):
+    def stop(self):
+        pass
+
+    def get_event_queue(self, task_id):
         pass
 
 
 class DummyTaskExecutor2(TaskExecutor):
-    pass
+    def run(self, task_config):
+        pass
+
+    def kill(self, task_id):
+        pass
+
+    def stop(self):
+        pass
+
+    def get_event_queue(self, task_id):
+        pass
 
 
 TASK_PROCESSING_PLUGIN = 'mock_plugin'

--- a/tests/unit/interfaces/retrying_executor_test.py
+++ b/tests/unit/interfaces/retrying_executor_test.py
@@ -1,0 +1,9 @@
+from unittest.mock import MagicMock
+
+from task_processing.plugins.mesos.retrying_executor import RetryingExecutor
+
+
+def test_event_creation():
+    r = RetryingExecutor(executor=MagicMock())
+    assert r
+    r.stop()

--- a/tests/unit/plugins/mesos/mesos_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_executor_test.py
@@ -25,7 +25,7 @@ def test_creates_execution_framework_and_driver(mesos_executor):
     ef = me_module.ExecutionFramework.return_value
     assert mesos_executor.execution_framework is ef
     me_module.ExecutionFramework.assert_called_with(
-        name="test",
+        name="taskproc-default",
         task_staging_timeout_s=60,
         translator=mesos_status_to_event,
         role="role"

--- a/tests/unit/plugins/mesos/mesos_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_executor_test.py
@@ -58,7 +58,7 @@ def test_stop_shuts_down_properly(mesos_executor):
     mesos_executor.driver.join.assert_called_with()
 
 
-def test_get_event_queue(mocker, mesos_executor):
+def test_event_queue(mocker, mesos_executor):
     q = mocker.Mock()
     mesos_executor.execution_framework.task_update_queue = q
     assert mesos_executor.get_event_queue() is q


### PR DESCRIPTION
# Description
- Added locks to execution framework
- Converted blacklisted_slaves and task_metadata from python dictionaries to pyrsistent pmaps
# Testing done
- Manual testing to check locks acquire and release
- Manual testing to check that persistent data structures are being re-set appropriately after changes
- Ran itest in examples
# Note to reviewers
- As per discussion with jolynch and sagarp, previous attempt using a function to metaclass data structures to enforce thread safety would not work as intended. In order to control race conditions, I made the above changes.
- Future developers on this code will need to be wary of the locked contexts, unfortunately.