### PR TITLE
Fixes to exec framework, retrying exec, sync runner

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -411,7 +411,7 @@ class ExecutionFramework(Scheduler):
             'TASK_FINISHED'
         ):
             with self._lock:
-                self.task_metadata.pop(task_id, None)
+                self.task_metadata = self.task_metadata.discard(task_id)
 
         # We have to do this because we are not using implicit
         # acknowledgements.

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -411,7 +411,7 @@ class ExecutionFramework(Scheduler):
             'TASK_FINISHED'
         ):
             with self._lock:
-                self.task_metadata = self.task_metadata.discard(task_id)
+                self.task_metadata.pop(task_id, None)
 
         # We have to do this because we are not using implicit
         # acknowledgements.

--- a/task_processing/plugins/mesos/retrying_executor.py
+++ b/task_processing/plugins/mesos/retrying_executor.py
@@ -9,9 +9,6 @@ from six.moves.queue import Queue
 
 from task_processing.interfaces.task_executor import TaskExecutor
 
-FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
-LEVEL = logging.DEBUG
-logging.basicConfig(format=FORMAT, level=LEVEL)
 log = logging.getLogger(__name__)
 
 
@@ -33,13 +30,14 @@ class RetryingExecutor(TaskExecutor):
         self.TASK_CONFIG_INTERFACE = executor.TASK_CONFIG_INTERFACE
 
         self.retry_thread = Thread(target=self.retry_loop)
+        self.retry_thread.daemon = True
         self.retry_thread.start()
 
     def event_with_retries(self, event):
         return event.transform(
             ('extensions', 'RetryingExecutor/tries'),
             "{}/{}".format(
-                self.retries - self.task_retries.get(event.task_id, -1),
+                1 + self.retries - self.task_retries.get(event.task_id, -1),
                 self.retries
             )
         )

--- a/task_processing/plugins/mesos/retrying_executor.py
+++ b/task_processing/plugins/mesos/retrying_executor.py
@@ -1,10 +1,18 @@
+import logging
 import time
+from operator import sub
+from threading import Lock
 from threading import Thread
 
 from pyrsistent import m
 from six.moves.queue import Queue
 
 from task_processing.interfaces.task_executor import TaskExecutor
+
+FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
+LEVEL = logging.DEBUG
+logging.basicConfig(format=FORMAT, level=LEVEL)
+log = logging.getLogger(__name__)
 
 
 class RetryingExecutor(TaskExecutor):
@@ -15,28 +23,61 @@ class RetryingExecutor(TaskExecutor):
         self.executor = executor
         self.retries = retries
         self.retry_pred = retry_pred
+
         self.task_retries = m()
+        self.task_retries_lock = Lock()
+
         self.src_queue = executor.get_event_queue()
         self.dest_queue = Queue()
-        self.retry_thread = Thread(target=self.retry_loop)
-        self.retry_thread.start()
         self.stopping = False
         self.TASK_CONFIG_INTERFACE = executor.TASK_CONFIG_INTERFACE
+
+        self.retry_thread = Thread(target=self.retry_loop)
+        self.retry_thread.start()
+
+    def event_with_retries(self, event):
+        return event.transform(
+            ('extensions', 'RetryingExecutor/tries'),
+            "{}/{}".format(
+                self.retries - self.task_retries.get(event.task_id, -1),
+                self.retries
+            )
+        )
+
+    def retry(self, event):
+        current_retries = self.task_retries.get(event.task_id, -1)
+        if current_retries <= 0:
+            return False
+
+        log.info(
+            'Retrying task {}, {} of {}, fail event: {}'.format(
+                event.task_config.name, 1 + self.retries - current_retries,
+                self.retries, event.raw
+            )
+        )
+
+        self.run(event.task_config)
+        with self.task_retries_lock:
+            self.task_retries = self.task_retries.update_with(
+                sub, {event.task_id: 1}
+            )
+        return True
 
     def retry_loop(self):
         while True:
             while not self.src_queue.empty():
-                e = self.src_queue.get()
-                if e.terminal and self.retry_pred(e):
-                    if self.task_retries[e.task_id] > 0:
-                        self.run(e.task_config)
-                        self.task_retries = self.task_retries.set(
-                            e.task_id, self.task_retries[e.task_id] - 1)
-                        continue
-                et = e.transform(
-                    ('extensions', 'retrying'),
-                    self.retries - self.task_retries[e.task_id])
-                self.dest_queue.put(et)
+                e = self.event_with_retries(self.src_queue.get())
+
+                if e.terminal:
+                    if self.retry_pred(e):
+                        if self.retry(e):
+                            continue
+                    else:
+                        with self.task_retries_lock:
+                            self.task_retries = \
+                                self.task_retries.remove(e.task_id)
+
+                self.dest_queue.put(e)
 
             if self.stopping:
                 return
@@ -44,12 +85,17 @@ class RetryingExecutor(TaskExecutor):
             time.sleep(1)
 
     def run(self, task_config):
-        self.tasks_retries[task_config.task_id] = self.retries
+        if task_config.task_id not in self.task_retries:
+            with self.task_retries_lock:
+                self.task_retries = self.task_retries.set(
+                    task_config.task_id, self.retries)
         self.executor.run(task_config)
 
     def kill(self, task_id):
         # retries = -1 so that manually killed tasks can be distinguished
-        self.tasks_retries = self.task_retries.set(task_id, -1)
+        with self.task_retries_lock:
+            self.tasks_retries = self.task_retries.update_with(
+                sub, {task_id: 1})
         self.executor.kill(task_id)
 
     def stop(self):

--- a/task_processing/plugins/mesos/translator.py
+++ b/task_processing/plugins/mesos/translator.py
@@ -6,7 +6,9 @@ from task_processing.interfaces.event import Event
 MESOS_TASK_STATUS_TO_EVENT = {
     'TASK_STARTING': Event(platform_type='starting', terminal=False),
     'TASK_RUNNING': Event(platform_type='running', terminal=False),
-    'TASK_FINISHED': Event(platform_type='finished', terminal=True),
+    'TASK_FINISHED': Event(platform_type='finished',
+                           terminal=True,
+                           success=True),
     'TASK_FAILED': Event(platform_type='failed', terminal=True),
     'TASK_KILLED': Event(platform_type='killed',
                          terminal=True),

--- a/task_processing/runners/sync.py
+++ b/task_processing/runners/sync.py
@@ -27,8 +27,6 @@ class Sync(Runner):
 
             if event.terminal:
                 return event
-            else:
-                print("Non-terminal event: %s", event)
 
     def stop(self):
         self.executor.stop()


### PR DESCRIPTION
- build docker parameters in exec framework
- cleanup leftovers of retry behavior in exec framework
- lock task retries map in retrying exec
- add logging to retrying exec
- cleanup task retries map after task is finished
- add success field to TASK_FINISHED event translator
- drop verbosity of sync runner