### PR TITLE
Add support for HA proxy

### DIFF
--- a/examples/async.py
+++ b/examples/async.py
@@ -24,7 +24,7 @@ def main():
         secret = f.read().strip()
     executor = MesosExecutor(
         secret=secret,
-        mesos_address=mesos_address,
+        mesos_info=mesos_address,
         role='task-proc'
     )
 

--- a/examples/dynamo_persistence.py
+++ b/examples/dynamo_persistence.py
@@ -20,7 +20,7 @@ def main():
         secret = f.read().strip()
     mesos_executor = MesosExecutor(
         secret=secret,
-        mesos_address=mesos_address,
+        mesos_info=mesos_address,
         role='task-proc'
     )
     s = session.Session(

--- a/examples/file_persistence.py
+++ b/examples/file_persistence.py
@@ -18,7 +18,7 @@ def main():
         secret = f.read().strip()
     mesos_executor = MesosExecutor(
         secret=secret,
-        mesos_address=mesos_address,
+        mesos_info=mesos_address,
         role='task-proc'
     )
     executor = StatefulTaskExecutor(

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -17,7 +17,7 @@ def main():
         secret = f.read().strip()
     executor = MesosExecutor(
         secret=secret,
-        mesos_address=mesos_address,
+        mesos_info=mesos_address,
         role='task-proc'
     )
 

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -34,6 +34,16 @@ def parse_sync_args():
         dest="secret",
         help="mesos secret to use"
     )
+    parser.add_argument(
+        '-c', '--cluster',
+        dest="cluster",
+        help="mesos master cluster"
+    )
+    parser.add_argument(
+        '-g', '--region',
+        dest="region",
+        help="mesos master region"
+    )
 
     args = parser.parse_args()
     return args
@@ -41,10 +51,12 @@ def parse_sync_args():
 
 def main():
     args = parse_sync_args()
-    if not args.master:
-        mesos_address = os.environ.get('MESOS', '127.0.0.1:5050')
+    if args.cluster and args.region:
+        mesos_info = (args.cluster, args.region)
+    elif args.master:
+        mesos_info = args.master
     else:
-        mesos_address = args.master
+        mesos_info = os.environ.get('MESOS', '127.0.0.1:5050')
 
     if not args.secret:
         with open('./examples/cluster/secret') as f:
@@ -54,7 +66,7 @@ def main():
 
     executor = MesosExecutor(
         secret=secret,
-        mesos_address=mesos_address,
+        mesos_info=mesos_info,
         pool=args.pool,
         role=args.role
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-hypothesis
 # Testing dependencies
+hypothesis
 mock
 pre-commit
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 -e .
 boto3
 pyrsistent
+PyYAML

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -14,6 +14,7 @@ from task_processing.plugins.mesos.execution_framework import (
     ExecutionFramework
 )
 from task_processing.plugins.mesos.translator import mesos_status_to_event
+from task_processing.plugins.smartstack import get_mesos_master
 FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
 LEVEL = logging.DEBUG
 logging.basicConfig(format=FORMAT, level=LEVEL)
@@ -56,7 +57,7 @@ class MesosExecutor(TaskExecutor):
         pool=None,
         principal='taskproc',
         secret=None,
-        mesos_address='127.0.0.1:5050',
+        mesos_info=('norcal_devc', 'uswest1-devc'),
         framework_translator=mesos_status_to_event,
         framework_name='taskproc-default',
         framework_staging_timeout=60,
@@ -78,7 +79,11 @@ class MesosExecutor(TaskExecutor):
             task_staging_timeout_s=framework_staging_timeout
         )
 
-        # TODO: Get mesos master ips from smartstack
+        if isinstance(mesos_info, tuple):
+            mesos_address = get_mesos_master(*mesos_info)
+        elif isinstance(mesos_info, str):
+            mesos_address = mesos_info
+
         self.driver = MesosSchedulerDriver(
             sched=self.execution_framework,
             framework=self.execution_framework.framework_info,

--- a/task_processing/plugins/smartstack.py
+++ b/task_processing/plugins/smartstack.py
@@ -1,0 +1,34 @@
+import yaml
+
+
+YOCALHOST_IP = '169.254.255.254'
+TASKPROC_SERVICE_FILE = '/nail/etc/services/task_processing/smartstack.yaml'
+
+
+class MesosLeaderNotFound(Exception):
+    pass
+
+
+class ProxyPortNotFound(Exception):
+    pass
+
+
+def get_mesos_master(cluster, region):
+    """ Finds the yocalhost ip:port for the Mesos master via SmartStack
+    Args customize granularity, defaults to a dev cluster for safety
+    """
+    with open(TASKPROC_SERVICE_FILE, 'r') as istream:
+        taskproc_conf = yaml.load(istream)
+
+    leader_name = 'mesos_leader_paasta_{cluster}_{region}'.format(
+        cluster=cluster,
+        region=region,
+    )
+
+    if leader_name not in taskproc_conf:
+        raise MesosLeaderNotFound(leader_name)
+    elif 'proxy_port' not in taskproc_conf[leader_name]:
+        raise ProxyPortNotFound
+    else:
+        proxy_port = taskproc_conf[leader_name]['proxy_port']
+        return YOCALHOST_IP + ':' + str(proxy_port)

--- a/tests/unit/plugins/smartstack_test.py
+++ b/tests/unit/plugins/smartstack_test.py
@@ -1,0 +1,54 @@
+import mock
+import pytest
+import yaml
+
+import task_processing.plugins.smartstack as smartstack
+
+
+@pytest.fixture(params=[
+    {},
+    {'proxy_port': 'fake_port'}
+])
+def mock_yamlload(request):
+    fake_conf = {'mesos_leader_paasta_fake_cluster_fake_region': request.param}
+
+    with mock.patch.object(yaml, 'load', return_value=fake_conf) as\
+            mock_yamlload:
+        yield mock_yamlload
+
+
+@pytest.mark.parametrize(
+    'mock_yamlload',
+    [{'proxy_port': 'fake_port'}],
+    indirect=True
+)
+def test_get_mesos_master(mock_yamlload):
+    smartstack.TASKPROC_SERVICE_FILE = '/dev/null'
+
+    master_ip = smartstack.get_mesos_master('fake_cluster', 'fake_region')
+
+    assert master_ip == '169.254.255.254:fake_port'
+
+
+@pytest.mark.parametrize(
+    'mock_yamlload',
+    [{'proxy_port': 'fake_port'}],
+    indirect=True
+)
+def test_get_mesos_master_no_leader(mock_yamlload):
+    smartstack.TASKPROC_SERVICE_FILE = '/dev/null'
+
+    with pytest.raises(smartstack.MesosLeaderNotFound) as exc_info:
+        smartstack.get_mesos_master('wrong_cluster', 'fake_region')
+
+    assert isinstance(exc_info.value, smartstack.MesosLeaderNotFound)
+
+
+@pytest.mark.parametrize('mock_yamlload', [{}], indirect=True)
+def test_get_mesos_master_no_port(mock_yamlload):
+    smartstack.TASKPROC_SERVICE_FILE = '/dev/null'
+
+    with pytest.raises(smartstack.ProxyPortNotFound) as exc_info:
+        smartstack.get_mesos_master('fake_cluster', 'fake_region')
+
+    assert isinstance(exc_info.value, smartstack.ProxyPortNotFound)


### PR DESCRIPTION
Summary of changes:
- add SmartStack plugin to get Mesos master info
- modified MesosExecutor to accept either a (cluster, region) or ip:port. Ideally, should be only the former, but need the latter for itests.
- update examples and tests to match
Testing:
- make test (with new SmartStack and modified MesosExecutor tests)
- examples excluding Promise - did not work previously, can't get it to work