### PR TITLE
blacklist agents with upcoming maintenance window

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -173,8 +173,9 @@ class ExecutionFramework(Scheduler):
         log.info(
             'Unblacklisting slave: {id}'.format(id=agent_id)
         )
-        self.blacklisted_slaves = \
-            self.blacklisted_slaves.discard(agent_id)
+        with self._lock:
+            self.blacklisted_slaves = \
+                self.blacklisted_slaves.discard(agent_id)
 
     def enqueue_task(self, task_config):
         with self._lock:

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -160,13 +160,13 @@ class ExecutionFramework(Scheduler):
             ))
             self.blacklisted_slaves = \
                 self.blacklisted_slaves.set(agent_id, time.time())
-            unblacklist_thread = threading.Thread(
-                target=self.unblacklist_slave,
-                kwargs={'timeout': timeout, 'agent_id': agent_id},
-            )
-            unblacklist_thread.daemon = True
-            unblacklist_thread.start()
             get_metric(BLACKLISTED_AGENTS_COUNT).count(1)
+        unblacklist_thread = threading.Thread(
+            target=self.unblacklist_slave,
+            kwargs={'timeout': timeout, 'agent_id': agent_id},
+        )
+        unblacklist_thread.daemon = True
+        unblacklist_thread.start()
 
     def unblacklist_slave(self, agent_id, timeout):
         time.sleep(timeout)

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -433,7 +433,7 @@ class ExecutionFramework(Scheduler):
             )
             now = int(time.time())
             duration = completion_time - now
-            if not time.time() > completion_time:
+            if duration > 0:
                 self.blacklist_slave(
                     agent_id=offer.agent_id.value,
                     timeout=duration,


### PR DESCRIPTION
blacklist the agent until the maintenance window is completed.
this rearchitects each blacklisted slave to have a separate thread
responsible for taking the node out of the blacklist, rather than a single
blacklist thread responsible for managing all blacklisted agents.