### PR TITLE
add an option for initial decline delay

### DIFF
--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -57,6 +57,7 @@ class MesosExecutor(TaskExecutor):
         principal='taskproc',
         secret=None,
         mesos_address='127.0.0.1:5050',
+        initial_decline_delay=1.0,
         framework_translator=mesos_status_to_event,
         framework_name='taskproc-default',
         framework_staging_timeout=60,
@@ -75,7 +76,8 @@ class MesosExecutor(TaskExecutor):
             pool=pool,
             name=framework_name,
             translator=framework_translator,
-            task_staging_timeout_s=framework_staging_timeout
+            task_staging_timeout_s=framework_staging_timeout,
+            initial_decline_delay=initial_decline_delay
         )
 
         # TODO: Get mesos master ips from smartstack

--- a/tests/unit/plugins/mesos/mesos_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_executor_test.py
@@ -36,6 +36,7 @@ def test_creates_execution_framework_and_driver(mock_Thread, mesos_executor):
     assert me_module.ExecutionFramework.call_args == mock.call(
         name="taskproc-default",
         task_staging_timeout_s=60,
+        initial_decline_delay=1.0,
         translator=mesos_status_to_event,
         pool=None,
         role="role"


### PR DESCRIPTION
lets avoid the situation where offers arrive before user is done with constructing the task configs