### PR TITLE
expose executor classes from plugin registry directly

### DIFF
--- a/task_processing/plugins/mesos/__init__.py
+++ b/task_processing/plugins/mesos/__init__.py
@@ -1,8 +1,11 @@
 from .mesos_executor import MesosExecutor
+from .retrying_executor import RetryingExecutor
 
 
 TASK_PROCESSING_PLUGIN = 'mesos_plugin'
 
 
 def register_plugin(registry):
-    return registry.register_task_executor('mesos', MesosExecutor)
+    return registry \
+        .register_task_executor('mesos', MesosExecutor) \
+        .register_task_executor('retrying', RetryingExecutor)

--- a/task_processing/task_processor.py
+++ b/task_processing/task_processor.py
@@ -96,7 +96,7 @@ class TaskProcessor(object):
             conflict_check, plugin_update, name_update
         )
 
-    def executor_from_config(self, provider, provider_config=None):
+    def executor_cls(self, provider):
         """Called by users of TaskProcessing to obtain :class:`TaskExecutor`s
 
         :param str provider: The kind of executor the user wants to run.
@@ -109,8 +109,10 @@ class TaskProcessor(object):
                     provider, self.registry.task_executors.keys().tolist()
                 )
             )
+        return self.registry.task_executors[provider]
+
+    def executor_from_config(self, provider, provider_config=None):
         if provider_config is None:
             provider_config = dict()
 
-        executor_cls = self.registry.task_executors[provider]
-        return executor_cls(**provider_config)
+        return self.executor_cls(provider)(**provider_config)


### PR DESCRIPTION
one use case - paasta needs to pull task config interface from MesosExecutor class which is much easier with this pr