### PR TITLE
fix event task_config and retrying executor

### DIFF
--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -31,7 +31,10 @@ class Event(PRecord):
     # task_id this event pertains to
     task_id = field(type=str)
     # task config dict that sourced the task this event refers to
-    task_config = field(type=PMap, factory=pmap)
+    task_config = field(
+        invariant=lambda x: (isinstance(x, PMap),
+                             'task_config must inherit from PMap'),
+        factory=lambda x: pmap(x) if not isinstance(x, PMap) else x)
     # the task finished with exit code 0
     success = field(type=(bool, type(None)), initial=None)
     # platform-specific event type

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -520,13 +520,14 @@ class ExecutionFramework(Scheduler):
 
         # Record state changes
         if md.task_state != task_state:
-            self.task_metadata = self.task_metadata.set(
-                task_id,
-                md.set(
-                    task_state=task_state,
-                    task_state_ts=time.time(),
+            with self._lock:
+                self.task_metadata = self.task_metadata.set(
+                    task_id,
+                    md.set(
+                        task_state=task_state,
+                        task_state_ts=time.time(),
+                    )
                 )
-            )
 
         if task_state in self._task_states:
             with self._lock:

--- a/task_processing/plugins/mesos/retrying_executor.py
+++ b/task_processing/plugins/mesos/retrying_executor.py
@@ -27,7 +27,6 @@ class RetryingExecutor(TaskExecutor):
         self.src_queue = executor.get_event_queue()
         self.dest_queue = Queue()
         self.stopping = False
-        self.TASK_CONFIG_INTERFACE = executor.TASK_CONFIG_INTERFACE
 
         self.retry_thread = Thread(target=self.retry_loop)
         self.retry_thread.daemon = True
@@ -66,7 +65,7 @@ class RetryingExecutor(TaskExecutor):
             while not self.src_queue.empty():
                 e = self.src_queue.get()
 
-                if e.kind == 'control':
+                if e.kind != 'task':
                     self.dest_queue.put(e)
                     continue
 

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -612,10 +612,7 @@ def test_duplicate_status_update(
     fake_driver,
     mock_get_metric
 ):
-    update, task_id, task_metadata = status_update_test_prep(
-        0,
-        'TASK_FINISHED'
-    )
+    update, task_id, task_metadata = status_update_test_prep('TASK_FINISHED')
     ef.translator = mock.Mock()
 
     ef.statusUpdate(fake_driver, update)


### PR DESCRIPTION
factory on task_config event field was coercing all PMap descendants to actual PMap instances, losing task_id property from MesosTaskConfig class

also minor fixes to locks and filtering of non-task events in retrying executor