### PR TITLE
Add gpu resource and mesos containerizer option

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -216,6 +216,7 @@ class ExecutionFramework(Scheduler):
         remaining_cpus = 0
         remaining_mem = 0
         remaining_disk = 0
+        remaining_gpus = 0
         available_ports = []
         for resource in offer.resources:
             if resource.name == "cpus" and resource.role == self.role:
@@ -224,17 +225,20 @@ class ExecutionFramework(Scheduler):
                 remaining_mem += resource.scalar.value
             elif resource.name == "disk" and resource.role == self.role:
                 remaining_disk += resource.scalar.value
+            elif resource.name == "gpus" and resource.role == self.role:
+                remaining_gpus += resource.scalar.value
             elif resource.name == "ports" and resource.role == self.role:
                 # TODO: Validate if the ports available > ports required
                 available_ports = self.get_available_ports(resource)
 
         log.info(
             "Received offer {id} with cpus: {cpu}, mem: {mem}, "
-            "disk: {disk} role: {role}".format(
+            "disk: {disk} gpus: {gpu} role: {role}".format(
                 id=offer.id.value,
                 cpu=remaining_cpus,
                 mem=remaining_mem,
                 disk=remaining_disk,
+                gpu=remaining_gpus,
                 role=self.role
             )
         )
@@ -295,6 +299,27 @@ class ExecutionFramework(Scheduler):
                 md.set(agent_id=str(offer.agent_id.value))
             )
 
+        docker = Dict(
+            type='DOCKER',
+            docker=Dict(
+                image=task_config.image,
+                network='BRIDGE',
+                force_pull_image=True,
+                port_mappings=[Dict(host_port=port_to_use,
+                                    container_port=8888)]
+            ),
+            parameters=thaw(task_config.docker_parameters),
+            volumes=thaw(task_config.volumes),
+        )
+        if task_config.containerizer == 'DOCKER':
+            container = docker
+        elif task_config.containerizer == 'MESOS':
+            docker.docker.name = docker.docker.pop('image')
+            container = Dict(
+                type='MESOS',
+                mesos=Dict(image=docker),
+            )
+
         return Dict(
             task_id=Dict(value=task_config.task_id),
             agent_id=Dict(value=offer.agent_id.value),
@@ -312,6 +337,10 @@ class ExecutionFramework(Scheduler):
                      type='SCALAR',
                      role=self.role,
                      scalar=Dict(value=task_config.disk)),
+                Dict(name='gpus',
+                     type='SCALAR',
+                     role=self.role,
+                     scalar=Dict(value=task_config.gpus)),
                 Dict(name='ports',
                      type='RANGES',
                      role=self.role,
@@ -323,16 +352,7 @@ class ExecutionFramework(Scheduler):
                 uris=[Dict(value=uri, extract=False)
                       for uri in task_config.uris]
             ),
-            container=Dict(
-                type='DOCKER',
-                docker=Dict(image=task_config.image,
-                            network='BRIDGE',
-                            force_pull_image=True,
-                            port_mappings=[Dict(host_port=port_to_use,
-                                                container_port=8888)]),
-                parameters=thaw(task_config.docker_parameters),
-                volumes=thaw(task_config.volumes)
-            )
+            container=container,
         )
 
     def stop(self):

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -48,6 +48,9 @@ class MesosTaskConfig(PRecord):
     disk = field(type=float,
                  initial=10.0,
                  invariant=lambda d: (d > 0, 'disk > 0'))
+    gpus = field(type=float,
+                 initial=0.0,
+                 invariant=lambda g: (g >= 0, 'gpus >= 0'))
     volumes = field(type=PVector,
                     initial=v(),
                     factory=pvector,
@@ -58,6 +61,11 @@ class MesosTaskConfig(PRecord):
     uris = field(type=PVector, initial=v(), factory=pvector)
     # TODO: containerization + containerization_args ?
     docker_parameters = field(type=PVector, initial=v(), factory=pvector)
+    containerizer = field(type=str,
+                          initial='DOCKER',
+                          invariant=lambda c:
+                          (c == 'DOCKER' or c == 'MESOS',
+                           'containerizer is docker or mesos'))
 
     @property
     def task_id(self):

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -301,38 +301,37 @@ def test_get_tasks_to_launch_insufficient_offer(
 @pytest.mark.parametrize('gpus_count,containerizer,container', [
     (1.0, 'MESOS', Dict(
         type='MESOS',
-        mesos=Dict(image=Dict(
-            type='DOCKER',
-            docker=Dict(
-                name='fake_image',
-                network='BRIDGE',
-                force_pull_image=True,
-                port_mappings=[Dict(host_port=31200,
-                                    container_port=8888)]
-            ),
-            parameters=[],
-            volumes=[Dict(
-                container_path='fake_container_path',
-                host_path='fake_host_path',
-                mode='RO'
-            )],
-        )),
-    )),
-    (0.0, 'DOCKER', Dict(
-        type='DOCKER',
-        docker=Dict(
-            image='fake_image',
-            network='BRIDGE',
-            force_pull_image=True,
-            port_mappings=[Dict(host_port=31200,
-                                container_port=8888)]
-        ),
-        parameters=[],
         volumes=[Dict(
             container_path='fake_container_path',
             host_path='fake_host_path',
             mode='RO'
         )],
+        mesos=Dict(
+            image=Dict(
+                type='DOCKER',
+                docker=Dict(name='fake_image'),
+            ),
+        ),
+        network_infos=Dict(
+            port_mappings=[Dict(host_port=31200,
+                                container_port=8888)],
+        ),
+    )),
+    (0.0, 'DOCKER', Dict(
+        type='DOCKER',
+        volumes=[Dict(
+            container_path='fake_container_path',
+            host_path='fake_host_path',
+            mode='RO'
+        )],
+        docker=Dict(
+            image='fake_image',
+            network='BRIDGE',
+            force_pull_image=True,
+            port_mappings=[Dict(host_port=31200,
+                                container_port=8888)],
+            parameters=[],
+        ),
     )),
 ])
 def test_create_new_docker_task(


### PR DESCRIPTION
## Summary
To run GPU jobs via taskproc, we ideally should use mesos containerizer, which we currently do not support. As such, I have:
- Added gpus as a resource
- Added a containerizer option to MesosTaskConfig
- Changed the config sent to Mesos to use either mesos or docker containerizer
## Testing
- make test
- Sync run on norcal-devc to a gpu instance (role isolated); cmd runs a script that uses pytorch to check for gpu availability.
## Additional Notes
- (DONE) ~~Mesos 1.3.0 has a [bug](https://issues.apache.org/jira/browse/MESOS-7692) in which env vars are not properly set in docker containers, which causes any gpu scripts to not be able to see gpus. The bug has been resolved but its patch has not been released, so @nhandler is working on applying the patch directly.~~
- To make gpu runs fully functional, mesos-slaves will need to run with different options that make gpu resources available. That will take additional puppet/soa config changes, but is beyond the scope of this issue.
- Currently, my mesos containerizer option still enforces use of docker, though the api message is slightly different; making this option more flexible is trivial but beyond the scope of this issue.
- Mesos containerizer automatically makes GPUs available to docker containers (pymesos helped with this).
- Docker images run in mesos containerizer are responsible for ensuring all the gpu drivers are present in their containers.