### PR TITLE
Add mesos master smartstack discovery as util

### DIFF
--- a/task_processing/utils.py
+++ b/task_processing/utils.py
@@ -1,0 +1,17 @@
+import yaml
+
+
+def get_cluster_master_by_proxy(
+    proxy_prefix,
+    cluster,
+    services_file='/nail/etc/services/services.yaml',
+):
+    with open(services_file, 'r') as istream:
+        services = yaml.load(istream)
+
+    proxy_name = 'task_processing.' + proxy_prefix + '_' + cluster
+    if proxy_name not in services:
+        raise KeyError('Cluster master {} was not found'.format(proxy_name))
+    else:
+        addr_info = services[proxy_name]
+        return addr_info['host'] + ':' + str(addr_info['port'])

--- a/tests/unit/utils_test.py
+++ b/tests/unit/utils_test.py
@@ -1,0 +1,43 @@
+import mock
+import pytest
+import yaml
+
+from task_processing import utils
+
+
+@pytest.fixture
+def mock_yamlload():
+    services = {
+        'task_processing.fake_prefix_fake_cluster': {
+            'host': 'fake_host',
+            'port': 'fake_port',
+        },
+    }
+
+    with mock.patch.object(
+        yaml,
+        'load',
+        return_value=services,
+    ) as mock_yamlload:
+        yield mock_yamlload
+
+
+def test_get_cluster_master_by_proxy(mock_yamlload):
+    proxy_addr = utils.get_cluster_master_by_proxy(
+        'fake_prefix',
+        'fake_cluster',
+        '/dev/null',
+    )
+
+    assert proxy_addr == 'fake_host:fake_port'
+
+
+def test_get_cluster_master_by_proxy_no_proxy(mock_yamlload):
+    with pytest.raises(KeyError) as exc_info:
+        utils.get_cluster_master_by_proxy(
+            'fake_prefix',
+            'wrong_cluster',
+            '/dev/null',
+        )
+
+    assert isinstance(exc_info.value, KeyError)


### PR DESCRIPTION
## Summary
- Added a util func to get mesos master (or any cluster master) from a services file
## Testing
- make test
- Manually run the func to get the address
## Notes
- Tried to exclude as much Yelp-y info as possible, but the default is still our own services file location