### PR TITLE
Fix gpus resource check and update tests

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -255,7 +255,8 @@ class ExecutionFramework(Scheduler):
 
                 if ((remaining_cpus >= task.cpus and
                      remaining_mem >= task.mem and
-                     remaining_disk >= task.disk)):
+                     remaining_disk >= task.disk and
+                     remaining_gpus >= task.gpus)):
                     # This offer is sufficient for us to launch task
                     tasks_to_launch.append(
                         self.create_new_docker_task(
@@ -270,6 +271,7 @@ class ExecutionFramework(Scheduler):
                     remaining_cpus -= task.cpus
                     remaining_mem -= task.mem
                     remaining_disk -= task.disk
+                    remaining_gpus -= task.gpus
 
                     get_metric(TASK_QUEUED_TIME_TIMER).record(
                         time.time() -


### PR DESCRIPTION
## Summary
While making puppet changes, I realized I hadn't properly updated the gpus resource checks and the tests weren't catching it. This PR fixes that.
## Testing
- make test (right and wrong cases)
- end-to-end run with gpu instance (mesos-slave started by modified puppet)
## Notes
- This error does not affect anyone not using gpus
