### PR TITLE
Reduce the number of signalfx time series with limited framework name

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -370,7 +370,7 @@ class ExecutionFramework(Scheduler):
     # TODO: add mesos cluster dimension when available
     def _initialize_metrics(self):
         default_dimensions = {
-            'framework_name': self.name,
+            'framework_name': '.'.join(self.name.split()[:2]),
             'framework_role': self.role
         }
 


### PR DESCRIPTION
The number of SignalFx time series keeps growing because paasta_remote_run includes a time stamp and a randomly generated ID in framework names. This patch drops both when creating metrics dimensions. 