### PR TITLE
Deal with TASK_LOST due to invalid offers

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -545,8 +545,8 @@ class ExecutionFramework(Scheduler):
         if task_id not in self.task_metadata:
             # We assume that a terminal status update has been
             # received for this task already.
-            log.info('Ignoring this status update because a terminal status'
-                     'update has been receiced for this task already.')
+            log.info('Ignoring this status update because a terminal status '
+                     'update has been received for this task already.')
             driver.acknowledgeStatusUpdate(update)
             return
 
@@ -561,8 +561,9 @@ class ExecutionFramework(Scheduler):
             # This task has not been launched. Therefore, we are going to
             # reenqueue it. We are not propogating any event up to the
             # application.
-            log.warning('Received TASK_LOST from mesos master because we'
-                        'attemted to accept an invalid offer.')
+            log.warning('Received TASK_LOST from mesos master because we '
+                        'attempted to accept an invalid offer. Going to re-'
+                        'enqueue this task {id}'.format(id=task_id))
             self.task_metadata = self.task_metadata.discard(task_id)
             self.enqueue_task(md.task_config)
             get_metric(TASK_LOST_DUE_TO_INVALID_OFFER_COUNT).count(1)

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -23,6 +23,8 @@ TASK_FINISHED_COUNT = 'taskproc.mesos.task_finished_count'
 TASK_FAILED_COUNT = 'taskproc.mesos.task_failure_count'
 TASK_KILLED_COUNT = 'taskproc.mesos.task_killed_count'
 TASK_LOST_COUNT = 'taskproc.mesos.task_lost_count'
+TASK_LOST_DUE_TO_INVALID_OFFER_COUNT = \
+    'taskproc.mesos.task_lost_due_to_invalid_offer_count'
 TASK_ERROR_COUNT = 'taskproc.mesos.task_error_count'
 
 TASK_ENQUEUED_COUNT = 'taskproc.mesos.task_enqueued_count'
@@ -377,11 +379,12 @@ class ExecutionFramework(Scheduler):
         }
 
         counters = [
-            TASK_LAUNCHED_COUNT,        TASK_FINISHED_COUNT,
-            TASK_FAILED_COUNT,          TASK_KILLED_COUNT,
-            TASK_LOST_COUNT,            TASK_ERROR_COUNT,
-            TASK_ENQUEUED_COUNT,        TASK_INSUFFICIENT_OFFER_COUNT,
-            TASK_STUCK_COUNT,           BLACKLISTED_AGENTS_COUNT,
+            TASK_LAUNCHED_COUNT,                 TASK_FINISHED_COUNT,
+            TASK_FAILED_COUNT,                   TASK_KILLED_COUNT,
+            TASK_LOST_COUNT,                     TASK_ERROR_COUNT,
+            TASK_ENQUEUED_COUNT,                 TASK_INSUFFICIENT_OFFER_COUNT,
+            TASK_STUCK_COUNT,                    BLACKLISTED_AGENTS_COUNT,
+            TASK_LOST_DUE_TO_INVALID_OFFER_COUNT
         ]
         for cnt in counters:
             create_counter(cnt, default_dimensions)
@@ -542,11 +545,29 @@ class ExecutionFramework(Scheduler):
         if task_id not in self.task_metadata:
             # We assume that a terminal status update has been
             # received for this task already.
-            log.info('Ignoring this status update because a terminal status \
-                update has been receiced for this task already.')
+            log.info('Ignoring this status update because a terminal status'
+                     'update has been receiced for this task already.')
             driver.acknowledgeStatusUpdate(update)
             return
+
         md = self.task_metadata[task_id]
+
+        # If we attempt to accept an offer that has been invalidated by master
+        # for some reason such as offer has been rescinded or we have exceeded
+        # offer_timeout, then we will get TASK_LOST status update back from
+        # mesos master.
+        if task_state == 'TASK_LOST' and \
+                'REASON_INVALID_OFFERS' == str(update.reason):
+            # This task has not been launched. Therefore, we are going to
+            # reenqueue it. We are not propogating any event up to the
+            # application.
+            log.warning('Received TASK_LOST from mesos master because we'
+                        'attemted to accept an invalid offer.')
+            self.task_metadata = self.task_metadata.discard(task_id)
+            self.enqueue_task(md.task_config)
+            get_metric(TASK_LOST_DUE_TO_INVALID_OFFER_COUNT).count(1)
+            driver.acknowledgeStatusUpdate(update)
+            return
 
         self.event_queue.put(
             self.translator(update, task_id).set(task_config=md.task_config)

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -700,7 +700,6 @@ def test_task_lost_due_to_invalid_offers(
 
     assert task_id in ef.task_metadata
     assert mock_get_metric.call_count == 2
-    assert len(ef.event_queue) == 0
-    assert len(ef.task_queue) == 1
-    assert ef.enqeueue_task.call_args == mock.call(task_metadata)
+    assert ef.event_queue.qsize() == 0
+    assert ef.task_queue.qsize() == 1
     assert fake_driver.acknowledgeStatusUpdate.call_count == 1

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -435,13 +435,14 @@ def test_initialize_metrics(ef):
 
     ef._initialize_metrics()
 
-    assert ef_mdl.create_counter.call_count == 10
+    assert ef_mdl.create_counter.call_count == 11
     ef_mdl_counters = [
         ef_mdl.TASK_LAUNCHED_COUNT,
         ef_mdl.TASK_FINISHED_COUNT,
         ef_mdl.TASK_FAILED_COUNT,
         ef_mdl.TASK_KILLED_COUNT,
         ef_mdl.TASK_LOST_COUNT,
+        ef_mdl.TASK_LOST_DUE_TO_INVALID_OFFER_COUNT,
         ef_mdl.TASK_ERROR_COUNT,
         ef_mdl.TASK_ENQUEUED_COUNT,
         ef_mdl.TASK_INSUFFICIENT_OFFER_COUNT,
@@ -611,12 +612,13 @@ def test_resource_offers_unmet_reqs(
     assert mock_get_metric.return_value.count.call_count == 0
 
 
-def status_update_test_prep(state):
+def status_update_test_prep(state, reason=''):
     task = me_mdl.MesosTaskConfig(name='fake_name')
     task_id = task.task_id
     update = Dict(
         task_id=Dict(value=task_id),
-        state=state
+        state=state,
+        reason=reason
     )
     task_metadata = ef_mdl.TaskMetadata(
         task_config=task,
@@ -677,4 +679,28 @@ def test_duplicate_status_update(
     assert task_id not in ef.task_metadata
     assert mock_get_metric.call_count == 0
     assert mock_get_metric.return_value.count.call_count == 0
+    assert fake_driver.acknowledgeStatusUpdate.call_count == 1
+
+
+def test_task_lost_due_to_invalid_offers(
+    ef,
+    fake_driver,
+    mock_get_metric
+):
+    update, task_id, task_metadata = status_update_test_prep(
+        state='TASK_LOST',
+        reason='REASON_INVALID_OFFERS'
+    )
+    ef.task_metadata = ef.task_metadata.set(
+        task_id,
+        task_metadata
+    )
+
+    ef.statusUpdate(fake_driver, update)
+
+    assert task_id in ef.task_metadata
+    assert mock_get_metric.call_count == 2
+    assert len(ef.event_queue) == 0
+    assert len(ef.task_queue) == 1
+    assert ef.enqeueue_task.call_args == mock.call(task_metadata)
     assert fake_driver.acknowledgeStatusUpdate.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,10 @@ deps =
 commands =
     pip install -e .[mesos_executor]
     - pip install yelp-meteorite
+    pytest --cov=task_processing --cov-fail-under=30 -v {posargs:tests}/unit
     pre-commit install -f --install-hooks
     pre-commit run --all-files
-    pytest --cov=task_processing --cov-fail-under=30 -v {posargs:tests}/unit
+
 
 [testenv:mesos]
 basepython = /usr/bin/python3.6


### PR DESCRIPTION
I think it is better to re-enqueue the task in execution_framework than doing it in retrying_executor because not all applications have to use retrying_executor. This is something that execution framework should be able to deal with.