### PR TITLE
Mutable task id

### DIFF
--- a/examples/dynamo_persistence.py
+++ b/examples/dynamo_persistence.py
@@ -59,15 +59,15 @@ def main():
         }
     )
     runner = Sync(executor=executor)
-    tasks = set()
     TaskConfig = mesos_executor.TASK_CONFIG_INTERFACE
-    for _ in range(1, 2):
-        task_config = TaskConfig(
-            image='ubuntu:14.04', cmd='/bin/sleep 2'
-        )
-        tasks.add(task_config.task_id)
-        runner.run(task_config)
-        print(executor.status(task_config.task_id))
+
+    for _ in range(2):
+        task_config = TaskConfig(image='ubuntu:14.04', cmd='/bin/true')
+        task_id = runner.new_task_id()
+        runner.run(task_config, task_id)
+        assert executor.status(task_id)[-1]['terminal']
+
+    print('OK')
 
 
 def create_table(client):

--- a/examples/dynamo_persistence.py
+++ b/examples/dynamo_persistence.py
@@ -5,6 +5,7 @@ import os
 from boto3 import session
 from botocore.errorfactory import ClientError
 
+from task_processing.interfaces.runner import new_task_id
 from task_processing.plugins.persistence.dynamodb_persistence \
     import DynamoDBPersister
 from task_processing.runners.sync import Sync
@@ -63,7 +64,7 @@ def main():
 
     for _ in range(2):
         task_config = TaskConfig(image='ubuntu:14.04', cmd='/bin/true')
-        task_id = runner.new_task_id()
+        task_id = new_task_id()
         runner.run(task_config, task_id)
         assert executor.status(task_id)[-1]['terminal']
 

--- a/examples/file_persistence.py
+++ b/examples/file_persistence.py
@@ -2,6 +2,7 @@
 import logging
 import os
 
+from task_processing.interfaces.runner import new_task_id
 from task_processing.plugins.persistence.file_persistence \
     import FilePersistence
 from task_processing.runners.sync import Sync
@@ -37,7 +38,7 @@ def main():
     )
 
     runner = Sync(executor=executor)
-    task_ids = [runner.new_task_id() for _ in range(2)]
+    task_ids = [new_task_id() for _ in range(2)]
     TaskConfig = mesos_executor.TASK_CONFIG_INTERFACE
 
     for task_id in task_ids:

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -36,8 +36,9 @@ def main():
     TaskConfig = executor.TASK_CONFIG_INTERFACE
     for _ in range(2):
         task_config = TaskConfig(image='busybox', cmd='/bin/true')
-        tasks.add(task_config.task_id)
-        runner.run(task_config)
+        task_id = runner.new_task_id()
+        tasks.add(task_id)
+        runner.run(task_config, task_id)
 
     print('Running {} tasks: {}'.format(len(tasks), tasks))
     while len(tasks) > 0:
@@ -54,7 +55,8 @@ def main():
                 tasks.discard(event.task_id)
 
     runner.stop()
-    return 0 if len(tasks) == 0 else 1
+    assert len(tasks) == 0
+    print('OK')
 
 
 if __name__ == '__main__':

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -5,6 +5,7 @@ import os
 from six.moves.queue import Empty
 from six.moves.queue import Queue
 
+from task_processing.interfaces.runner import new_task_id
 from task_processing.runners.subscription import Subscription
 from task_processing.task_processor import TaskProcessor
 
@@ -36,7 +37,7 @@ def main():
     TaskConfig = executor.TASK_CONFIG_INTERFACE
     for _ in range(2):
         task_config = TaskConfig(image='busybox', cmd='/bin/true')
-        task_id = runner.new_task_id()
+        task_id = new_task_id()
         tasks.add(task_id)
         runner.run(task_config, task_id)
 

--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -7,8 +7,6 @@ from pyrsistent import m
 from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
-from pyrsistent import PVector
-from pyrsistent import pvector
 
 
 EVENT_KINDS = ['task', 'control']
@@ -31,10 +29,7 @@ class Event(PRecord):
 
     # task-specific fields
     # task_id this event pertains to
-    task_id = field(
-        type=PVector,
-        factory=lambda x: pvector(x) if isinstance(x, list) else None,
-    )
+    task_id = field(type=str)
     # task config dict that sourced the task this event refers to
     task_config = field(
         invariant=lambda x: (isinstance(x, PMap),

--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -31,7 +31,10 @@ class Event(PRecord):
 
     # task-specific fields
     # task_id this event pertains to
-    task_id = field(type=PVector, factory=pvector)
+    task_id = field(
+        type=PVector,
+        factory=lambda x: pvector(x) if isinstance(x, list) else None,
+    )
     # task config dict that sourced the task this event refers to
     task_config = field(
         invariant=lambda x: (isinstance(x, PMap),

--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -7,6 +7,8 @@ from pyrsistent import m
 from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
+from pyrsistent import PVector
+from pyrsistent import pvector
 
 
 EVENT_KINDS = ['task', 'control']
@@ -29,7 +31,7 @@ class Event(PRecord):
 
     # task-specific fields
     # task_id this event pertains to
-    task_id = field(type=str)
+    task_id = field(type=PVector, factory=pvector)
     # task config dict that sourced the task this event refers to
     task_config = field(
         invariant=lambda x: (isinstance(x, PMap),

--- a/task_processing/interfaces/runner.py
+++ b/task_processing/interfaces/runner.py
@@ -1,10 +1,10 @@
 import abc
-import uuid
 
 import six
 from pyrsistent import pvec
 
 from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
+from task_processing.utils.base62 import base62_random
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -24,4 +24,4 @@ class Runner(object):
         pass
 
     def new_task_id():
-        return pvec(uuid.uuid4())
+        return pvec(base62_random())

--- a/task_processing/interfaces/runner.py
+++ b/task_processing/interfaces/runner.py
@@ -1,10 +1,10 @@
 import abc
 
 import six
-from pyrsistent import pvec
+from pyrsistent import pvector
 
 from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
-from task_processing.utils.base62 import base62_random
+from task_processing.util.base62 import base62_random
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -24,4 +24,4 @@ class Runner(object):
         pass
 
     def new_task_id():
-        return pvec(base62_random())
+        return pvector(base62_random())

--- a/task_processing/interfaces/runner.py
+++ b/task_processing/interfaces/runner.py
@@ -23,5 +23,5 @@ class Runner(object):
     def kill(self, task_id):
         pass
 
-    def new_task_id():
-        return pvector(base62_random())
+    def new_task_id(self):
+        return pvector([base62_random()])

--- a/task_processing/interfaces/runner.py
+++ b/task_processing/interfaces/runner.py
@@ -1,7 +1,6 @@
 import abc
 
 import six
-from pyrsistent import pvector
 
 from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
 from task_processing.util.base62 import base62_random
@@ -23,5 +22,6 @@ class Runner(object):
     def kill(self, task_id):
         pass
 
-    def new_task_id(self):
-        return pvector([base62_random()])
+
+def new_task_id():
+    return base62_random()

--- a/task_processing/interfaces/runner.py
+++ b/task_processing/interfaces/runner.py
@@ -1,6 +1,8 @@
 import abc
+import uuid
 
 import six
+from pyrsistent import pvec
 
 from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
 
@@ -14,9 +16,12 @@ class Runner(object):
     """
 
     @abc.abstractmethod
-    def run(self, task_config):
+    def run(self, task_config, task_id=None):
         pass
 
     @abc.abstractmethod
     def kill(self, task_id):
         pass
+
+    def new_task_id():
+        return pvec(uuid.uuid4())

--- a/task_processing/interfaces/task_executor.py
+++ b/task_processing/interfaces/task_executor.py
@@ -28,7 +28,7 @@ class TaskExecutor(object):
         The executor should start running the provided task and return the
         task id.
 
-        :returns pvector task_id: Callers get the id of the task that was run
+        :returns str task_id: Callers get the id of the task that was run
         to check status or kill it later
         """
         pass
@@ -51,6 +51,6 @@ class TaskExecutor(object):
     def get_event_queue(self):
         """Get queue of events
 
-        :returns: Object with .pull and .push methods defined on it.
+        :returns: Object with .get and .put methods defined on it.
         """
         pass

--- a/task_processing/interfaces/task_executor.py
+++ b/task_processing/interfaces/task_executor.py
@@ -1,14 +1,11 @@
 import abc
-import uuid
 
 import six
-from pyrsistent import field
 from pyrsistent import PRecord
 
 
 class DefaultTaskConfigInterface(PRecord):
-    task_id = field(type=uuid.UUID, initial=uuid.uuid4)
-    name = field(type=str, initial='default')
+    pass
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -24,14 +21,14 @@ class TaskExecutor(object):
     """
 
     @abc.abstractmethod
-    def run(self, task_config):
-        """Run the supplied task
+    def run(self, task_config, task_id):
+        """Run the supplied task with task_id.
 
         :param task_config: An object satistfying the TASK_CONFIG_INTERFACE
         The executor should start running the provided task and return the
         task id.
 
-        :returns str task_id: Callers get the id of the task that was run
+        :returns pvector task_id: Callers get the id of the task that was run
         to check status or kill it later
         """
         pass
@@ -54,6 +51,6 @@ class TaskExecutor(object):
     def get_event_queue(self):
         """Get queue of events
 
-        :returns: TBD
+        :returns: Object with .pull and .push methods defined on it.
         """
         pass

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -9,8 +9,6 @@ from pyrsistent import m
 from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
-from pyrsistent import PVector
-from pyrsistent import pvector
 from pyrsistent import thaw
 from pyrsistent import v
 from six.moves.queue import Queue
@@ -47,7 +45,7 @@ log = logging.getLogger(__name__)
 
 
 class TaskMetadata(PRecord):
-    task_id = field(type=PVector, factory=pvector, mandatory=True)
+    task_id = field(type=str, mandatory=True)
     agent_id = field(type=str, initial='')
     task_config = field(type=PRecord, mandatory=True)
     task_state = field(type=str, mandatory=True)

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -589,8 +589,9 @@ class ExecutionFramework(Scheduler):
             log.warning('Received TASK_LOST from mesos master because we '
                         'attempted to accept an invalid offer. Going to re-'
                         'enqueue this task {id}'.format(id=task_id))
-            self.task_metadata = self.task_metadata.discard(task_id)
-            self.enqueue_task(md.task_config)
+
+            self.enqueue_task(md.task_config, task_id)
+
             get_metric(TASK_LOST_DUE_TO_INVALID_OFFER_COUNT).count(1)
             driver.acknowledgeStatusUpdate(update)
             return

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -124,8 +124,8 @@ class MesosExecutor(TaskExecutor):
         self.driver_thread.daemon = True
         self.driver_thread.start()
 
-    def run(self, task_config):
-        self.execution_framework.enqueue_task(task_config)
+    def run(self, task_config, task_id):
+        self.execution_framework.enqueue_task(task_config, task_id)
 
     def kill(self, task_id):
         print("Killing")

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -1,6 +1,5 @@
 import logging
 import threading
-import uuid
 
 from pymesos import MesosSchedulerDriver
 from pyrsistent import field
@@ -38,7 +37,6 @@ def valid_volumes(volumes):
 
 
 class MesosTaskConfig(PRecord):
-    uuid = field(type=uuid.UUID, initial=uuid.uuid4)
     name = field(type=str, initial="default")
     image = field(type=str, initial="ubuntu:xenial")
     cmd = field(type=str, initial="/bin/true")
@@ -74,10 +72,6 @@ class MesosTaskConfig(PRecord):
                           (c == 'DOCKER' or c == 'MESOS',
                            'containerizer is docker or mesos'))
     environment = field(type=PMap, initial=m(), factory=pmap)
-
-    @property
-    def task_id(self):
-        return "{}.{}".format(self.name, str(self.uuid))
 
 
 class MesosExecutor(TaskExecutor):

--- a/task_processing/plugins/mesos/retrying_executor.py
+++ b/task_processing/plugins/mesos/retrying_executor.py
@@ -87,12 +87,13 @@ class RetryingExecutor(TaskExecutor):
 
             time.sleep(1)
 
-    def run(self, task_config):
-        if task_config.task_id not in self.task_retries:
+    def run(self, task_config, task_id):
+        if task_id not in self.task_retries:
             with self.task_retries_lock:
                 self.task_retries = self.task_retries.set(
-                    task_config.task_id, self.retries)
-        self.executor.run(task_config)
+                    task_id, self.retries)
+
+        self.executor.run(task_config, task_id)
 
     def kill(self, task_id):
         # retries = -1 so that manually killed tasks can be distinguished

--- a/task_processing/plugins/mesos/translator.py
+++ b/task_processing/plugins/mesos/translator.py
@@ -29,6 +29,6 @@ MESOS_STATUS_MAP = {
 def mesos_status_to_event(mesos_status, task_id):
     return MESOS_STATUS_MAP[mesos_status.state].set(
         raw=mesos_status,
-        task_id=str(task_id),
+        task_id=task_id,
         timestamp=time.time(),
     )

--- a/task_processing/plugins/stateful/stateful_executor.py
+++ b/task_processing/plugins/stateful/stateful_executor.py
@@ -20,8 +20,8 @@ class StatefulTaskExecutor(TaskExecutor):
         worker_thread.daemon = True
         worker_thread.start()
 
-    def run(self, task_config):
-        self.downstream_executor.run(task_config)
+    def run(self, task_config, task_id):
+        self.downstream_executor.run(task_config, task_id)
 
     def kill(self, task_id):
         return self.downstream_executor.kill(task_id)

--- a/task_processing/runners/async.py
+++ b/task_processing/runners/async.py
@@ -3,6 +3,7 @@ from threading import Thread
 
 from six.moves.queue import Empty
 
+from task_processing.interfaces.runner import new_task_id
 from task_processing.interfaces.runner import Runner
 
 EventHandler = namedtuple('EventHandler', ['predicate', 'cb'])
@@ -28,7 +29,7 @@ class Async(Runner):
 
     def run(self, task_config, task_id=None):
         if task_id is None:
-            task_id = self.new_task_id()
+            task_id = new_task_id()
 
         return self.executor.run(task_config, task_id)
 

--- a/task_processing/runners/async.py
+++ b/task_processing/runners/async.py
@@ -26,10 +26,13 @@ class Async(Runner):
         self.callback_t.daemon = True
         self.callback_t.start()
 
-    def run(self, task_config):
-        return self.executor.run(task_config)
+    def run(self, task_config, task_id=None):
+        if task_id is None:
+            task_id = self.new_task_id()
 
-    def kill(self, task_config):
+        return self.executor.run(task_config, task_id)
+
+    def kill(self, task_id):
         pass
 
     def callback_loop(self):

--- a/task_processing/runners/promise.py
+++ b/task_processing/runners/promise.py
@@ -5,5 +5,5 @@ class Promise(Runner):
     def __init__(self, executor):
         pass
 
-    def run(self, task_config):
+    def run(self, task_config, task_id=None):
         pass

--- a/task_processing/runners/subscription.py
+++ b/task_processing/runners/subscription.py
@@ -3,6 +3,7 @@ from threading import Thread
 from six.moves.queue import Empty
 from six.moves.queue import Full
 
+from task_processing.interfaces.runner import new_task_id
 from task_processing.interfaces.runner import Runner
 
 
@@ -31,7 +32,7 @@ class Subscription(Runner):
 
     def run(self, task_config, task_id=None):
         if task_id is None:
-            task_id = self.new_task_id()
+            task_id = new_task_id()
 
         return self.executor.run(task_config, task_id)
 

--- a/task_processing/runners/subscription.py
+++ b/task_processing/runners/subscription.py
@@ -29,8 +29,11 @@ class Subscription(Runner):
             except Full:
                 pass
 
-    def run(self, task_config):
-        return self.executor.run(task_config)
+    def run(self, task_config, task_id=None):
+        if task_id is None:
+            task_id = self.new_task_id()
+
+        return self.executor.run(task_config, task_id)
 
     def kill(self, task_id):
         return self.executor.kill(task_id)

--- a/task_processing/runners/sync.py
+++ b/task_processing/runners/sync.py
@@ -17,8 +17,11 @@ class Sync(Runner):
     def kill(self, *args):
         pass
 
-    def run(self, task_config):
-        self.executor.run(task_config)
+    def run(self, task_config, task_id=None):
+        if task_id is None:
+            task_id = self.new_task_id()
+
+        self.executor.run(task_config, task_id)
         event_queue = self.executor.get_event_queue()
 
         while True:
@@ -29,7 +32,7 @@ class Sync(Runner):
                 log.info('Stop event received: {}'.format(event))
                 return event
 
-            if event.task_id != task_config.task_id:
+            if event.task_id != task_id:
                 event_queue.put(event)
                 time.sleep(1)  # hope somebody else picks it up?
                 continue

--- a/task_processing/runners/sync.py
+++ b/task_processing/runners/sync.py
@@ -3,6 +3,7 @@ import time
 
 from six.moves.queue import Queue
 
+from task_processing.interfaces.runner import new_task_id
 from task_processing.interfaces.runner import Runner
 
 log = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ class Sync(Runner):
 
     def run(self, task_config, task_id=None):
         if task_id is None:
-            task_id = self.new_task_id()
+            task_id = new_task_id()
 
         self.executor.run(task_config, task_id)
         event_queue = self.executor.get_event_queue()

--- a/task_processing/util/base62.py
+++ b/task_processing/util/base62.py
@@ -1,0 +1,30 @@
+import os
+
+BASE62 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def encode(num):
+    if num == 0:
+        return BASE62[0]
+    arr = []
+    while num:
+        num, rem = divmod(num, 62)
+        arr.append(BASE62[rem])
+    arr.reverse()
+    return ''.join(arr)
+
+
+def decode(string):
+    strlen = len(string)
+    num = 0
+    idx = 0
+    for char in string:
+        power = (strlen - (idx + 1))
+        num += BASE62.index(char) * (62 ** power)
+        idx += 1
+
+    return num
+
+
+def base62_random():
+    return encode(int.from_bytes(os.urandom(16), byteorder='big'))

--- a/tests/unit/interfaces/event_test.py
+++ b/tests/unit/interfaces/event_test.py
@@ -2,6 +2,7 @@ import pytest
 from pyrsistent import InvariantException
 from pyrsistent import PRecord
 from pyrsistent import PTypeError
+from pyrsistent import v
 
 from task_processing.interfaces.event import Event
 
@@ -24,7 +25,7 @@ def test_event_is_immutable(event):
 
 
 def test_event_has_task_id(event):
-    assert event.set(task_id='foo').task_id == 'foo'
+    assert event.set(task_id=['foo']).task_id == v('foo')
 
 
 def test_event_type_checks(event):

--- a/tests/unit/interfaces/event_test.py
+++ b/tests/unit/interfaces/event_test.py
@@ -2,7 +2,6 @@ import pytest
 from pyrsistent import InvariantException
 from pyrsistent import PRecord
 from pyrsistent import PTypeError
-from pyrsistent import v
 
 from task_processing.interfaces.event import Event
 
@@ -25,7 +24,7 @@ def test_event_is_immutable(event):
 
 
 def test_event_has_task_id(event):
-    assert event.set(task_id=['foo']).task_id == v('foo')
+    assert event.set(task_id='foo').task_id == 'foo'
 
 
 def test_event_type_checks(event):

--- a/tests/unit/interfaces/retrying_executor_test.py
+++ b/tests/unit/interfaces/retrying_executor_test.py
@@ -1,9 +1,0 @@
-from unittest.mock import MagicMock
-
-from task_processing.plugins.mesos.retrying_executor import RetryingExecutor
-
-
-def test_event_creation():
-    r = RetryingExecutor(executor=MagicMock())
-    assert r
-    r.stop()

--- a/tests/unit/plugins/mesos/mesos_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_executor_test.py
@@ -61,9 +61,9 @@ def test_creates_execution_framework_and_driver(mock_Thread, mesos_executor):
 
 
 def test_run_passes_task_to_execution_framework(mesos_executor):
-    mesos_executor.run("task")
+    mesos_executor.run("task", ["fake_id"])
     assert mesos_executor.execution_framework.enqueue_task.call_args ==\
-        mock.call("task")
+        mock.call("task", ["fake_id"])
 
 
 def test_stop_shuts_down_properly(mesos_executor):

--- a/tests/unit/plugins/mesos/retrying_executor_test.py
+++ b/tests/unit/plugins/mesos/retrying_executor_test.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock
+
+from mock import patch
+from six.moves.queue import Queue
+
+from task_processing.interfaces.event import Event
+from task_processing.interfaces.runner import new_task_id
+from task_processing.plugins.mesos.retrying_executor import RetryingExecutor
+
+
+def test_executor_creation():
+    retrying = RetryingExecutor(executor=MagicMock())
+    retrying.stop()
+
+
+@patch('time.sleep', return_value=None)
+def test_executor_grows_id_by_atttempt(_):
+    downstream_tasks = Queue()
+    downstream_events = Queue()
+    downstream = MagicMock(
+        run=lambda *args: downstream_tasks.put(args),
+        get_event_queue=lambda: downstream_events
+    )
+    retrying = RetryingExecutor(executor=downstream)
+    task_config = {'name': 'fake_task'}
+    task_id = new_task_id()
+
+    retrying.run(task_config, task_id)
+
+    downstream_task = downstream_tasks.get(True, 0.01)
+    assert (task_config, task_id + ':0') == downstream_task
+
+    downstream_events.put(
+        Event(
+            kind='task',
+            task_id=task_id + ':0',
+            task_config=task_config,
+            terminal=True,
+            success=False,
+            raw=MagicMock(),
+        )
+    )
+
+    downstream_task = downstream_tasks.get(True, 0.01)
+    assert (task_config, task_id + ':1') == downstream_task
+
+    retrying.stop()
+
+
+@patch('time.sleep', return_value=None)
+def test_executor_retries_x_times(_):
+    downstream_tasks = Queue()
+    downstream_events = Queue()
+    downstream = MagicMock(
+        run=lambda *args: downstream_tasks.put(args),
+        get_event_queue=lambda: downstream_events
+    )
+    retrying = RetryingExecutor(executor=downstream)
+    task_config = {'name': 'fake_task'}
+    task_id = new_task_id()
+
+    retrying.run(task_config, task_id)
+    for i in range(4):
+        downstream_events.put(
+            Event(
+                kind='task',
+                task_id=task_id + ':' + str(i),
+                task_config=task_config,
+                terminal=True,
+                success=False,
+                raw=MagicMock(),
+            )
+        )
+
+    retrying_q = retrying.get_event_queue()
+    fail_event = retrying_q.get(True, 0.01)
+    assert fail_event
+
+    retrying.stop()

--- a/tests/unit/plugins/mesos/retrying_executor_test.py
+++ b/tests/unit/plugins/mesos/retrying_executor_test.py
@@ -27,7 +27,7 @@ def test_executor_grows_id_by_atttempt(_):
 
     retrying.run(task_config, task_id)
 
-    downstream_task = downstream_tasks.get(True, 0.01)
+    downstream_task = downstream_tasks.get(True, 0.1)
     assert (task_config, task_id + ':0') == downstream_task
 
     downstream_events.put(
@@ -41,7 +41,7 @@ def test_executor_grows_id_by_atttempt(_):
         )
     )
 
-    downstream_task = downstream_tasks.get(True, 0.01)
+    downstream_task = downstream_tasks.get(True, 0.1)
     assert (task_config, task_id + ':1') == downstream_task
 
     retrying.stop()
@@ -73,7 +73,7 @@ def test_executor_retries_x_times(_):
         )
 
     retrying_q = retrying.get_event_queue()
-    fail_event = retrying_q.get(True, 0.01)
+    fail_event = retrying_q.get(True, 0.1)
     assert fail_event
 
     retrying.stop()

--- a/tests/unit/plugins/mesos/translator_test.py
+++ b/tests/unit/plugins/mesos/translator_test.py
@@ -9,4 +9,4 @@ def test_translator_maps_status_to_event():
     for k in MESOS_STATUS_MAP:
         mesos_status = MagicMock()
         mesos_status.state = k
-        assert isinstance(mesos_status_to_event(mesos_status, ['123']), Event)
+        assert isinstance(mesos_status_to_event(mesos_status, '123'), Event)

--- a/tests/unit/plugins/mesos/translator_test.py
+++ b/tests/unit/plugins/mesos/translator_test.py
@@ -9,4 +9,4 @@ def test_translator_maps_status_to_event():
     for k in MESOS_STATUS_MAP:
         mesos_status = MagicMock()
         mesos_status.state = k
-        assert isinstance(mesos_status_to_event(mesos_status, 123), Event)
+        assert isinstance(mesos_status_to_event(mesos_status, ['123']), Event)

--- a/tests/unit/plugins/persistence/dynamo_persistence_test.py
+++ b/tests/unit/plugins/persistence/dynamo_persistence_test.py
@@ -2,6 +2,7 @@ import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
+from pyrsistent import thaw
 
 from task_processing.interfaces.event import Event
 from task_processing.plugins.persistence.dynamodb_persistence \
@@ -74,7 +75,7 @@ events = st.builds(
 @settings(max_examples=50)
 @given(x=events)
 def test_event_to_item_timestamp(x, persister):
-    res = persister._event_to_item(x)['M']
+    res = persister._event_to_item(thaw(x))['M']
     print(res)
     assert 'N' in res['timestamp'].keys()
     assert 'BOOL' in res['success'].keys()
@@ -85,7 +86,7 @@ def test_event_to_item_timestamp(x, persister):
 @settings(max_examples=50)
 @given(x=events)
 def test_event_to_item_list(x, persister):
-    res = persister._event_to_item(x)['M']
+    res = persister._event_to_item(thaw(x))['M']
     for k, v in x.task_config.items():
         if len(v) > 0:
             assert k in res['task_config']['M']


### PR DESCRIPTION
- move task_id out of task config
- task_id is collection of strings
- allow stack layers to extend/shrink task_id as it travels the stack with task runs and events
- use base62 encoded ids instead of much more verbose uuids, underlying data is the same - random 16 bytes