### PR TITLE
Rename slave to agent

### DIFF
--- a/examples/cluster/docker-compose.yaml
+++ b/examples/cluster/docker-compose.yaml
@@ -11,21 +11,21 @@ services:
     ports:
       - 5050
       - 5054
-    command: 'mesos-master --zk=zk://zookeeper:2181/mesos-testcluster --registry=in_memory --quorum=1 --authenticate --authenticate_slaves --work_dir=/tmp/mesos --credentials=/etc/mesos-secrets'
+    command: 'mesos-master --zk=zk://zookeeper:2181/mesos-testcluster --registry=in_memory --quorum=1 --authenticate --authenticate_agents --work_dir=/tmp/mesos --credentials=/etc/mesos-secrets'
     depends_on:
       - zookeeper
     volumes:
       - ./mesos-secrets:/etc/mesos-secrets
-  mesosslave:
+  mesosagent:
     image: mesosphere/mesos:1.3.0
     expose:
       - 5051
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./mesos-slave-secret:/etc/mesos-slave-secret
+      - ./mesos-agent-secret:/etc/mesos-agent-secret
     environment:
       CLUSTER: testcluster
-    command: 'mesos-slave --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus:20;mem:2048;disk:2000;ports:[31000-31100];cpus(task-proc):10;mem(task-proc):1024;disk(task-proc):1000;ports(task-proc):[31200-31500]" --credential=/etc/mesos-slave-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default" --no-docker_kill_orphans --log_dir=/var/log/mesos'
+    command: 'mesos-agent --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus:20;mem:2048;disk:2000;ports:[31000-31100];cpus(task-proc):10;mem(task-proc):1024;disk(task-proc):1000;ports(task-proc):[31200-31500]" --credential=/etc/mesos-agent-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default" --no-docker_kill_orphans --log_dir=/var/log/mesos'
     depends_on:
       - mesosmaster
       - zookeeper
@@ -39,7 +39,7 @@ services:
     depends_on:
       - zookeeper
       - mesosmaster
-      - mesosslave
+      - mesosagent
       - dynamodb
     volumes:
       - ../..:/src

--- a/examples/cluster/mesos-agent-secret
+++ b/examples/cluster/mesos-agent-secret
@@ -1,0 +1,4 @@
+ {
+   "principal": "agent",
+   "secret": "secretagent"
+ }

--- a/examples/cluster/mesos-secrets
+++ b/examples/cluster/mesos-secrets
@@ -5,8 +5,8 @@
       "secret": "secret"
     },
     {
-      "principal": "slave",
-      "secret": "secretslave"
+      "principal": "agent",
+      "secret": "secretagent"
     }
   ]
 }

--- a/examples/cluster/mesos-slave-secret
+++ b/examples/cluster/mesos-slave-secret
@@ -1,4 +1,0 @@
- {
-   "principal": "slave",
-   "secret": "secretslave"
- }

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
   docker-compose -f examples/cluster/docker-compose.yaml pull
   docker-compose -f examples/cluster/docker-compose.yaml build
   docker-compose -f examples/cluster/docker-compose.yaml \
-    up -d zookeeper mesosmaster mesosslave
-  docker-compose -f examples/cluster/docker-compose.yaml scale mesosslave=1
+    up -d zookeeper mesosmaster mesosagent
+  docker-compose -f examples/cluster/docker-compose.yaml scale mesosagent=1
   docker-compose -f examples/cluster/docker-compose.yaml \
     run playground /src/itest


### PR DESCRIPTION
This PR builds upon #60 to rename `slave` terminology to the canonical `agent` form (see [MESOS-1478](https://issues.apache.org/jira/browse/MESOS-1478) for context). 

I have not changed the scheduler code itself.