### PR TITLE
Discard offers with 0 ports

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -258,7 +258,8 @@ class ExecutionFramework(Scheduler):
                 if ((remaining_cpus >= task.cpus and
                      remaining_mem >= task.mem and
                      remaining_disk >= task.disk and
-                     remaining_gpus >= task.gpus)):
+                     remaining_gpus >= task.gpus and
+                     len(available_ports) > 0)):
                     # This offer is sufficient for us to launch task
                     tasks_to_launch.append(
                         self.create_new_docker_task(
@@ -585,8 +586,8 @@ class ExecutionFramework(Scheduler):
                     )
                 )
 
-        if task_state in self._task_states:
-            with self._lock:
+        with self._lock:
+            if task_state in self._task_states:
                 self.task_metadata = self.task_metadata.discard(task_id)
             get_metric(self._task_states[task_state]).count(1)
 

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -586,8 +586,8 @@ class ExecutionFramework(Scheduler):
                     )
                 )
 
-        with self._lock:
-            if task_state in self._task_states:
+        if task_state in self._task_states:
+            with self._lock:
                 self.task_metadata = self.task_metadata.discard(task_id)
             get_metric(self._task_states[task_state]).count(1)
 

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -535,6 +535,7 @@ def test_get_tasks_to_launch_no_ports(
 
     assert len(tasks) == 0
     assert ef.task_queue.qsize() == 1
+    assert ef.create_new_docker_task.call_count == 0
 
 
 def test_get_tasks_to_launch_ports_available(
@@ -561,6 +562,7 @@ def test_get_tasks_to_launch_ports_available(
 
     assert len(tasks) == 1
     assert ef.task_queue.qsize() == 0
+    assert ef.create_new_docker_task.call_count == 1
 
 
 def test_resource_offers_no_tasks_to_launch(


### PR DESCRIPTION
Currently, we are not honoring ports field in task_config. Users can pass more than one port to map, but we are mapping 8888 internal port to one of the available ports. This can be fixed in another review.