### PR TITLE
TimeoutExecutor

### DIFF
--- a/examples/common.py
+++ b/examples/common.py
@@ -1,0 +1,41 @@
+import argparse
+import os
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Runs a task processing task'
+    )
+
+    parser.add_argument(
+        '-m', '--master',
+        dest="master",
+        default=os.environ.get('MESOS', '127.0.0.1:5050'),
+        help="mesos master address"
+    )
+
+    parser.add_argument(
+        '-p', '--pool',
+        dest="pool",
+        help="mesos resource pool to use"
+    )
+
+    parser.add_argument(
+        '-r', '--role',
+        dest="role",
+        default='taskproc',
+        help="mesos reservation role to use"
+    )
+
+    with open('./examples/cluster/secret') as f:
+        default_secret = f.read().strip()
+
+    parser.add_argument(
+        '-s', '--secret',
+        dest="secret",
+        default=default_secret,
+        help="mesos secret to use"
+    )
+
+    args = parser.parse_args()
+    return args

--- a/task_processing/plugins/mesos/__init__.py
+++ b/task_processing/plugins/mesos/__init__.py
@@ -1,5 +1,6 @@
 from .mesos_executor import MesosExecutor
 from .retrying_executor import RetryingExecutor
+from .timeout_executor import TimeoutExecutor
 
 
 TASK_PROCESSING_PLUGIN = 'mesos_plugin'
@@ -8,4 +9,5 @@ TASK_PROCESSING_PLUGIN = 'mesos_plugin'
 def register_plugin(registry):
     return registry \
         .register_task_executor('mesos', MesosExecutor) \
-        .register_task_executor('retrying', RetryingExecutor)
+        .register_task_executor('retrying', RetryingExecutor) \
+        .register_task_executor('timeout', TimeoutExecutor)

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -65,6 +65,10 @@ class MesosTaskConfig(PRecord):
                  initial=0,
                  factory=int,
                  invariant=lambda g: (g >= 0, 'gpus >= 0'))
+    timeout = field(type=float,
+                    factory=float,
+                    mandatory=False,
+                    invariant=lambda t: (t > 0, 'timeout > 0'))
     volumes = field(type=PVector,
                     initial=v(),
                     factory=pvector,
@@ -141,7 +145,7 @@ class MesosExecutor(TaskExecutor):
         self.execution_framework.enqueue_task(task_config)
 
     def kill(self, task_id):
-        print("Killing")
+        self.execution_framework.kill_task(task_id)
 
     def stop(self):
         self.execution_framework.stop()

--- a/task_processing/plugins/mesos/timeout_executor.py
+++ b/task_processing/plugins/mesos/timeout_executor.py
@@ -1,0 +1,111 @@
+import collections
+import logging
+import time
+from threading import Lock
+from threading import Thread
+
+from six.moves.queue import Queue
+
+from task_processing.interfaces.task_executor import TaskExecutor
+
+log = logging.getLogger(__name__)
+
+TaskEntry = collections.namedtuple('TaskEntry', ['task_id', 'deadline'])
+
+
+class TimeoutExecutor(TaskExecutor):
+    def __init__(self, downstream_executor):
+        self.downstream_executor = downstream_executor
+
+        self.tasks_lock = Lock()
+        # Tasks that are pending termination
+        self.killed_tasks = []
+        # Tasks that are currently running
+        self.running_tasks = []
+
+        self.src_queue = downstream_executor.get_event_queue()
+        self.dest_queue = Queue()
+        self.stopping = False
+
+        self.timeout_thread = Thread(target=self.timeout_loop)
+        self.timeout_thread.daemon = True
+        self.timeout_thread.start()
+
+    def timeout_loop(self):
+        while True:
+            # process downstream events
+            while not self.src_queue.empty():
+                e = self.src_queue.get()
+                self.dest_queue.put(e)
+
+                if not (e.kind == 'task' and e.terminal):
+                    continue
+                # Update running and killed tasks
+                with self.tasks_lock:
+                    for idx, entry in enumerate(self.running_tasks):
+                        if e.task_id == entry.task_id:
+                            self.running_tasks.pop(idx)
+                            break
+                    if e.task_id in self.killed_tasks:
+                        self.killed_tasks.remove(e.task_id)
+
+            # Check timeouts
+            current_time = time.time()
+            with self.tasks_lock:
+                delete_idx = None
+                for idx, entry in enumerate(self.running_tasks):
+                    if entry.deadline < current_time:
+                        log.info(
+                            'Killing task {}: timed out'.format(entry.task_id))
+                        self.downstream_executor.kill(entry.task_id)
+                        self.killed_tasks.append(entry.task_id)
+                        delete_idx = idx
+                    # Skip the rest of tasks in the list because they are
+                    # appended to the list later.
+                    else:
+                        break
+                if delete_idx is not None:
+                    self.running_tasks = self.running_tasks[delete_idx + 1:]
+
+            if self.stopping:
+                return
+
+            # Since src_queue has to be polled continuously, sleep(1) is used.
+            # Otherwise, a notify() from run() plus wait(delta between now and
+            # the earliest deadline) is more efficient.
+            time.sleep(1)
+
+    def run(self, task_config):
+        # Tasks are dynamically added and removed from running_tasks and
+        # and killed_tasks. It's preferable for the client or execution
+        # framework to check for duplicated tasks.
+        new_entry = TaskEntry(
+            task_id=task_config.task_id,
+            deadline=task_config.timeout + time.time()
+        )
+        with self.tasks_lock:
+            for idx, entry in enumerate(self.running_tasks):
+                if new_entry.deadline <= entry.deadline:
+                    self.running_tasks.insert(idx, new_entry)
+                    return
+            self.running_tasks.append(new_entry)
+
+        self.downstream_executor.run(task_config)
+
+    def kill(self, task_id):
+        with self.tasks_lock:
+            for idx, entry in enumerate(self.running_tasks):
+                if task_id == entry.task_id:
+                    self.running_tasks.pop(idx)
+                    self.killed_tasks.append(task_id)
+                    log.info('Killing task {}: requested'.format(task_id))
+                    self.downstream_executor.kill(task_id)
+                    return
+
+    def stop(self):
+        self.downstream_executor.stop()
+        self.stopping = True
+        self.timeout_thread.join()
+
+    def get_event_queue(self):
+        return self.dest_queue

--- a/tests/unit/interfaces/timeout_executor_test.py
+++ b/tests/unit/interfaces/timeout_executor_test.py
@@ -1,0 +1,10 @@
+from unittest.mock import MagicMock
+
+from task_processing.plugins.mesos.timeout_executor import TimeoutExecutor
+
+
+def test_executor_creation():
+    t = TimeoutExecutor(downstream_executor=MagicMock())
+    assert t
+    t.kill('fake_task_id')
+    t.stop()


### PR DESCRIPTION
I had to prefix the example test command sleep with dumb-init. Otherwise, TASK_KILLED took 120 seconds because SIGTERM was not delivered to the sleep process and we use 120 seconds as mesos agent docker_stop_timeout. 