### PR TITLE
Making the repo more newbie friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,94 @@
-# Generic task processing
+# Task Processing
 [![Build Status](https://travis-ci.org/Yelp/task_processing.svg?branch=master)](https://travis-ci.org/Yelp/task_processing)
 
-Interfaces and shared infrastructure for generic task processing @ Yelp
+Interfaces and shared infrastructure for generic task processing (also known as `taskproc`) at Yelp.
 
-# Structure
+## Developer Setup
 
-## /interfaces
+### Pre-requisites
 
-### Event
++ [Docker](https://www.docker.com/get-docker)
++ [Python 3.6](https://www.python.org/downloads/)
++ [Virtualenv](https://virtualenv.pypa.io/en/stable/installation/)
 
-### Runner
+### Running examples
 
-### TaskExecutor
+[hello-world.py](/examples/hello-world/py) is a very simple annotated example that launches a task to echo `hello world`. From the root of the repository, run:
 
-## /plugins
+    docker-compose -f examples/cluster/docker-compose.yaml \
+      run playground examples/hello-world.py
 
-### mesos
+This will bring up a single master, single agent Mesos cluster using [Docker Compose](https://docs.docker.com/compose/) and launch a single task which will print "hello world" to the sandbox's stdout before terminating.
 
-Implements all required interfaces to talk to Mesos deployment.
+Other examples available include:
++ async  
+Example of the [async](#async) task runner.
 
-#### Configuration options
++ dynamo_persistence.py  
+Example that shows how task events may be persisted to [DynamoDB](https://aws.amazon.com/dynamodb) using the `stateful` plugin..
+
++ file_persistence.py  
+Example that shows how task events may be persisted to disk using the `stateful` plugin.
+
++ promise.py  
+Example that shows how the [promise/future](#Promise/Future) task runner (not yet implemented) may be used.
+
++ subscription.py  
+Example of the [subscription](#subscription) task runner.
+
++ sync.py  
+Brief example using the [sync](#sync) task runner.
+
+### Running tests
+
+From the root of the repository, run:
+
+    make
+
+## Repository Structure
+
+### /interfaces
+
+#### Event
+
+#### Runner
+
+#### TaskExecutor
+
+### /plugins
+
+#### Mesos
+
+Implements all required interfaces to talk to Mesos deployment. This plugin uses [PyMesos](https://github.com/douban/pymesos) to communicate with Mesos.
+
+##### Configuration options
 
 - authentication\_principal Mesos principal
 - credential\_secret\_file path to file containing Mesos secret
 - mesos\_address host:port to connect to Mesos cluster
 - event_translator a fucntion that maps Mesos-specific events to `Event` objects
 
-## /runners
+#### stateful
+
+TODO: documentation
+
+### /runners
 
 Runners provide specific concurrency semantics and are supposed to be
 platform independent.
 
-### Sync
+#### Sync
 
-Running a task is a blocking operation.
+Running a task is a blocking operation. `sync` runners block until the running task has completed or a `stop` event is received.
 
-### Async
+#### Async
 
-Provide callbacks for different events in tasks' lifecycle.
+Provide callbacks for different events in tasks' lifecycle. `async` runners allow tasks to specify one or more EventHandlers which consist of predicates and callbacks. Predicates are evaluated when an update is received from the task (e.g. that it has terminated and whether or not it has succeded) and if the predicate passes, the callback is called.
 
-### Promise/Future
+#### Promise/Future
 
 Running a task returns future object.
 
-### Subscription
+#### Subscription
 
 Provide a queue object and receive all events in there.
-
-# How do i try it?
-
-There are some examples in `/examples`. To run them you need docker and
-docker-compose.
-
-    cd examples/cluster/
-    docker-compose run playground examples/sync.py

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,0 @@
-# Running examples
-
-In root of the repository, run:
-
-    docker-compose -f examples/cluster/docker-compose.yaml \
-      run playground examples/sync.py

--- a/examples/async.py
+++ b/examples/async.py
@@ -32,7 +32,7 @@ def main():
         provider_config={
             'secret': secret,
             'mesos_address': mesos_address,
-            'role': 'task-proc',
+            'role': 'taskproc',
         }
     )
 

--- a/examples/cluster/docker-compose.yaml
+++ b/examples/cluster/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       - ./mesos-agent-secret:/etc/mesos-agent-secret
     environment:
       CLUSTER: testcluster
-    command: 'mesos-agent --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus:20;mem:2048;disk:2000;ports:[31000-31100];cpus(task-proc):10;mem(task-proc):1024;disk(task-proc):1000;ports(task-proc):[31200-31500]" --credential=/etc/mesos-agent-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default" --no-docker_kill_orphans --log_dir=/var/log/mesos'
+    command: 'mesos-agent --master=zk://zookeeper:2181/mesos-testcluster --resources="cpus:20;mem:2048;disk:2000;ports:[31000-31100];cpus(taskproc):10;mem(taskproc):1024;disk(taskproc):1000;ports(taskproc):[31200-31500]" --credential=/etc/mesos-agent-secret --containerizers=docker --docker=/usr/bin/docker --work_dir=/tmp/mesos --attributes="region:fakeregion;pool:default" --no-docker_kill_orphans --log_dir=/var/log/mesos'
     depends_on:
       - mesosmaster
       - zookeeper

--- a/examples/dynamo_persistence.py
+++ b/examples/dynamo_persistence.py
@@ -28,7 +28,7 @@ def main():
         provider_config={
             'secret': secret,
             'mesos_address': mesos_address,
-            'role': 'task-proc',
+            'role': 'taskproc',
         }
     )
 

--- a/examples/file_persistence.py
+++ b/examples/file_persistence.py
@@ -25,7 +25,7 @@ def main():
         provider_config={
             'secret': secret,
             'mesos_address': mesos_address,
-            'role': 'task-proc',
+            'role': 'taskproc',
         }
     )
     executor = processor.executor_from_config(

--- a/examples/hello-world.py
+++ b/examples/hello-world.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import os
+
+from task_processing.runners.sync import Sync
+from task_processing.task_processor import TaskProcessor
+
+"""Simple hello-world example of how to use Task Processing (taskproc)
+"""
+
+
+def main():
+    # get address of the Mesos cluster
+    mesos_address = os.getenv('MESOS', 'mesosmaster:5050')
+
+    # read in secret, this is used to authenticate the taskproc scheduler with
+    # Mesos
+    with open('./examples/cluster/secret') as f:
+        secret = f.read().strip()
+
+    # create a processor instance
+    processor = TaskProcessor()
+
+    # configure plugins
+    processor.load_plugin(provider_module='task_processing.plugins.mesos')
+
+    # create an executor (taskproc executor NOT to be confused with a Mesos
+    # executor) using this defined configuration. this config can also be used
+    # to specify other Mesos properties, such as which role to use
+    executor = processor.executor_from_config(
+        provider='mesos',
+        provider_config={
+            'secret': secret,
+            'mesos_address': mesos_address,
+            'role': 'taskproc',
+        }
+    )
+
+    # creates a new Sync runner that will synchronously execute tasks
+    # (i.e. block until completion)
+    runner = Sync(executor)
+
+    # next, create a TaskConfig to run
+    # this is where properties of the Mesos task can be specified in this
+    # example, we use the busybox Docker image and just echo "hello world"
+    TaskConfig = executor.TASK_CONFIG_INTERFACE
+    task_config = TaskConfig(image="busybox", cmd='echo "hello world"')
+
+    # run our task and print the result
+    result = runner.run(task_config)
+    print(result)
+
+    # this stops the taskproc framework and unregisters it from Mesos
+    runner.stop()
+
+    return 0 if result.success else 1
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/examples/promise.py
+++ b/examples/promise.py
@@ -16,7 +16,7 @@ def main():
     executor = MesosExecutor(
         credentials=credentials,
         mesos_address=mesos_address,
-        role='task-proc'
+        role='taskproc'
     )
     task_config = make_task_config(image="busybox", cmd="/bin/true")
     runner = Promise(executor)

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -25,7 +25,7 @@ def main():
         provider_config={
             'secret': secret,
             'mesos_address': mesos_address,
-            'role': 'task-proc',
+            'role': 'taskproc',
         }
     )
 

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -28,7 +28,7 @@ def parse_sync_args():
     parser.add_argument(
         '-r', '--role',
         dest="role",
-        default='task-proc',
+        default='taskproc',
         help="mesos reservation role to use"
     )
     parser.add_argument(

--- a/itest
+++ b/itest
@@ -2,7 +2,12 @@
 
 set -eux
 
-examples/file_persistence.py
-examples/sync.py
 examples/async.py
+examples/file_persistence.py
+examples/hello-world.py
 examples/subscription.py
+examples/sync.py
+
+# TODO: These should probably also be run eventually:
+# examples/promise.py
+# examples/dynamo_persistence.py

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'pyrsistent'
     ],
     extras_require={
-        # We can add the mesos specific dependencies here
+        # We can add the Mesos specific dependencies here
         'mesos_executor': ['pymesos'],
         'metrics': ['yelp-meteorite'],
     }

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -535,7 +535,7 @@ class ExecutionFramework(Scheduler):
 
         for reason, items in declined.items():
             if items:
-                log.info("Offers declined because {}: {}".format(
+                log.info("Offers declined because of {}: {}".format(
                     reason, ', '.join(items)))
         if accepted:
             log.info("Offers accepted: {}".format(', '.join(accepted)))

--- a/task_processing/runners/async.py
+++ b/task_processing/runners/async.py
@@ -13,6 +13,9 @@ class AsyncError(Exception):
 
 
 class Async(Runner):
+    # TODO: "callbacks" is inconsistent with the EventHandler terminology
+    # above. This should either be event_handlers, or
+    # EventHandler should be Callback
     def __init__(self, executor, callbacks=None):
         if not callbacks:
             raise AsyncError("must provide at least one callback")

--- a/task_processing/task_processor.py
+++ b/task_processing/task_processor.py
@@ -47,7 +47,7 @@ class TaskProcessor(object):
     This is the entrypoint to registering plugins (which know how to
     actually run tasks) and creating instances of TaskExecutors. Note that
     since most customers of this library will be importing this class into
-    their code, let's try to make it Python2/3 compatible
+    their code, let's try to make it Python2/3 compatible.
 
     Typical use would be:
 


### PR DESCRIPTION
I did a few things here to make this repo a little more approachable:
+ Preferred `taskproc` as the canonical shorthand for Task Processing
+ Tidied up README and added a little more detail
+ Miscellaneous grammatical fixes.
+ Added a super simple annotated "hello-world" example.
+ Added all examples to itest except for promise (which doesn't appear to be implemented) and dynamodb (which I presume requires an external service to be running).

Still to do (in a separate pull request):
+ dynamodb_persistence should be dynamo_persistence (or we should rename the example and the test file to match)
+ We should pin to a specific version of PyMesos in our requirements.txt (this is unlikely / should not conflict with applications' own dependencies)