### PR TITLE
Support mesos containerizer without an image

### DIFF
--- a/examples/sync.py
+++ b/examples/sync.py
@@ -68,6 +68,8 @@ def main():
 
     TaskConfig = executor.TASK_CONFIG_INTERFACE
     task_config = TaskConfig(image="busybox", cmd='/bin/true')
+    # This only works on agents that have added mesos as a containerizer
+    # task_config = TaskConfig(containerizer='MESOS', cmd='/bin/true')
 
     runner = Sync(executor)
     result = runner.run(task_config)

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -327,17 +327,20 @@ class ExecutionFramework(Scheduler):
                 type='MESOS',
                 # for docker, volumes should include parameters
                 volumes=thaw(task_config.volumes),
-                mesos=Dict(
-                    image=Dict(
-                        type='DOCKER',
-                        docker=Dict(name=task_config.image),
-                    ),
-                ),
                 network_infos=Dict(
                     port_mappings=[Dict(host_port=port_to_use,
                                         container_port=8888)],
                 ),
             )
+            # For this to work, image_providers needs to be set to 'docker'
+            # on mesos agents
+            if 'image' in task_config:
+                container.mesos = Dict(
+                    image=Dict(
+                        type='DOCKER',
+                        docker=Dict(name=task_config.image),
+                    )
+                )
 
         return Dict(
             task_id=Dict(value=task_config.task_id),

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -38,9 +38,14 @@ def valid_volumes(volumes):
 
 
 class MesosTaskConfig(PRecord):
+    def __invariant__(conf): return ('image' in conf if conf.containerizer ==
+                                     'DOCKER' else True,
+                                     'Image required for chosen containerizer')
+
     uuid = field(type=uuid.UUID, initial=uuid.uuid4)
     name = field(type=str, initial="default")
-    image = field(type=str, initial="ubuntu:xenial")
+    # image is optional for the mesos containerizer
+    image = field(type=str)
     cmd = field(type=str, initial="/bin/true")
     cpus = field(type=float,
                  initial=0.1,

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -291,6 +291,7 @@ def test_get_tasks_to_launch_insufficient_offer(
     ef.create_new_docker_task = mock.Mock()
     task = me_mdl.MesosTaskConfig(
         name='fake_name',
+        image='fake_image',
         cpus=task_cpus,
         mem=task_mem,
         disk=task_disk,
@@ -658,7 +659,7 @@ def test_resource_offers_unmet_reqs(
 
 
 def status_update_test_prep(state, reason=''):
-    task = me_mdl.MesosTaskConfig(name='fake_name')
+    task = me_mdl.MesosTaskConfig(name='fake_name', image='fake_image')
     task_id = task.task_id
     update = Dict(
         task_id=Dict(value=task_id),

--- a/tests/unit/plugins/mesos/mesos_task_config_test.py
+++ b/tests/unit/plugins/mesos/mesos_task_config_test.py
@@ -2,7 +2,7 @@ from task_processing.plugins.mesos.mesos_executor import MesosTaskConfig
 
 
 def test_mesos_task_config_factories():
-    m = MesosTaskConfig(cpus=1, mem=64, disk=15, gpus=6.0)
+    m = MesosTaskConfig(cpus=1, mem=64, disk=15, gpus=6.0, image='fake_image')
 
     assert type(m.cpus) is float
     assert m.cpus == 1.0


### PR DESCRIPTION
This is TASKPROC-78. Mesos containerizer with Docker image support has been completed for the GPU work. This is to support running a command directly in a mesos containerizer.