### PR TITLE
Deal with launchTasks failures.

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -118,12 +118,37 @@ class ExecutionFramework(Scheduler):
             with self._lock:
                 time_now = time.time()
                 for task_id in self.task_metadata.keys():
-                    if self.task_metadata[task_id].task_state not in (
+                    eligible_for_termination_at = self.task_metadata[task_id].\
+                        task_state_ts + self.task_staging_timeout_s
+
+                    md = self.task_metadata[task_id]
+
+                    if time_now < eligible_for_termination_at:
+                        return
+
+                    if md.task_state == 'UNKNOWN':
+                        with self._lock:
+                            self.task_metadata = self.task_metadata.discard(
+                                task_id
+                            )
+                            self.enqueue_task(md.task_config)
+
+                            print('Would have killed and'
+                                  're-enqueued the task')
+                            continue
+
+                    if md.task_state == \
+                            'SHOULD BE KILLED':
+                        # This task has been stuck for longer than the
+                        # specified timeout. Attempt to kill it again.
+                        self.kill_task(task_id)
+                        continue
+
+                    if md.task_state not in (
                         'TASK_STAGING',
                     ):
                         continue
 
-                    md = self.task_metadata[task_id]
                     if time_now > (
                         md.task_state_history['TASK_STAGING'] +
                         self.task_staging_timeout_s
@@ -568,23 +593,40 @@ class ExecutionFramework(Scheduler):
 
         md = self.task_metadata[task_id]
 
-        # If we attempt to accept an offer that has been invalidated by master
-        # for some reason such as offer has been rescinded or we have exceeded
-        # offer_timeout, then we will get TASK_LOST status update back from
-        # mesos master.
-        if task_state == 'TASK_LOST' and \
-                'REASON_INVALID_OFFERS' == str(update.reason):
-            # This task has not been launched. Therefore, we are going to
-            # reenqueue it. We are not propogating any event up to the
-            # application.
-            log.warning('Received TASK_LOST from mesos master because we '
-                        'attempted to accept an invalid offer. Going to re-'
-                        'enqueue this task {id}'.format(id=task_id))
-            self.task_metadata = self.task_metadata.discard(task_id)
-            self.enqueue_task(md.task_config)
-            get_metric(TASK_LOST_DUE_TO_INVALID_OFFER_COUNT).count(1)
-            driver.acknowledgeStatusUpdate(update)
-            return
+        if task_state == 'TASK_LOST':
+            # If we attempt to accept an offer that has been invalidated by
+            # master for some reason such as offer has been rescinded or we
+            # have exceeded offer_timeout, then we will get TASK_LOST status
+            # update back from mesos master.
+            if 'REASON_INVALID_OFFERS' == str(update.reason):
+                # This task has not been launched. Therefore, we are going to
+                # reenqueue it. We are not propogating any event up to the
+                # application.
+                log.warning('Received TASK_LOST from mesos master because we '
+                            'attempted to accept an invalid offer. Going to '
+                            're-enqueue this task {id}'.format(id=task_id))
+                with self._lock:
+                    self.task_metadata = self.task_metadata.discard(task_id)
+                    self.enqueue_task(md.task_config)
+                get_metric(TASK_LOST_DUE_TO_INVALID_OFFER_COUNT).count(1)
+                driver.acknowledgeStatusUpdate(update)
+                return
+
+            elif str(update.message) == 'Reconciliation: Task is unknown':
+                # This could be a duplicate status update; we need to
+                # check if this is a duplicate update or not
+                if md.task_state == 'UNKNOWN':
+                    with self._lock:
+                        log.warning('Reenquing task {id} because we failed to '
+                                    'launch the task'.format(
+                                        id=task_id
+                                    ))
+                        self.task_metadata = self.task_metadata.discard(
+                            task_id
+                        )
+                        self.enqueue_task(md.task_config)
+                driver.acknowledgeStatusUpdate(update)
+                return
 
         self.event_queue.put(
             self.translator(update, task_id).set(task_config=md.task_config)

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -146,8 +146,7 @@ class ExecutionFramework(Scheduler):
                                     )
                                     )
                         # Re-enqueue task
-                        self.enqueue_task(self.task_metadata[task_id].
-                                          task_config)
+                        self.enqueue_task(md.task_config)
                         get_metric(TASK_LAUNCH_FAILED_COUNT).count(1)
                         continue
 
@@ -643,7 +642,7 @@ class ExecutionFramework(Scheduler):
                         'attempted to accept an invalid offer. Going to '
                         're-enqueue this task {id}'.format(id=task_id))
             # Re-enqueue task
-            self.enqueue_task(self.task_metadata[task_id].task_config)
+            self.enqueue_task(md.task_config)
             get_metric(TASK_LOST_DUE_TO_INVALID_OFFER_COUNT).count(1)
             driver.acknowledgeStatusUpdate(update)
             return

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -22,6 +22,7 @@ from task_processing.plugins.mesos.translator import mesos_status_to_event
 
 
 TASK_LAUNCHED_COUNT = 'taskproc.mesos.task_launched_count'
+TASK_FAILED_TO_LAUNCH_COUNT = 'taskproc.mesos.tasks_failed_to_launch_count'
 TASK_LAUNCH_FAILED_COUNT = 'taskproc.mesos.task_launch_failed_count'
 TASK_FINISHED_COUNT = 'taskproc.mesos.task_finished_count'
 TASK_FAILED_COUNT = 'taskproc.mesos.task_failure_count'
@@ -146,7 +147,7 @@ class ExecutionFramework(Scheduler):
                                     ))
                         # Re-enqueue task
                         self.enqueue_task(md.task_config)
-                        get_metric(TASK_LAUNCH_FAILED_COUNT).count(1)
+                        get_metric(TASK_FAILED_TO_LAUNCH_COUNT).count(1)
                         continue
 
                     else:
@@ -440,7 +441,7 @@ class ExecutionFramework(Scheduler):
             TASK_ENQUEUED_COUNT,                 TASK_INSUFFICIENT_OFFER_COUNT,
             TASK_STUCK_COUNT,                    BLACKLISTED_AGENTS_COUNT,
             TASK_LOST_DUE_TO_INVALID_OFFER_COUNT,
-            TASK_LAUNCH_FAILED_COUNT
+            TASK_LAUNCH_FAILED_COUNT,            TASK_FAILED_TO_LAUNCH_COUNT
         ]
         for cnt in counters:
             create_counter(cnt, default_dimensions)
@@ -582,6 +583,7 @@ class ExecutionFramework(Scheduler):
                             )
                             )
                 task_launch_failed = True
+                get_metric(TASK_LAUNCH_FAILED_COUNT).count(1)
 
             # 'UNKNOWN' state is for internal tracking. It will not be
             # propogated to users.

--- a/task_processing/runners/async.py
+++ b/task_processing/runners/async.py
@@ -37,8 +37,8 @@ class Async(Runner):
     def run(self, task_config):
         return self.executor.run(task_config)
 
-    def kill(self, task_config):
-        pass
+    def kill(self, task_id):
+        self.executor.kill(task_id)
 
     def callback_loop(self):
         event_queue = self.executor.get_event_queue()

--- a/task_processing/runners/subscription.py
+++ b/task_processing/runners/subscription.py
@@ -33,7 +33,7 @@ class Subscription(Runner):
         return self.executor.run(task_config)
 
     def kill(self, task_id):
-        return self.executor.kill(task_id)
+        self.executor.kill(task_id)
 
     def stop(self):
         self.executor.stop()

--- a/task_processing/runners/sync.py
+++ b/task_processing/runners/sync.py
@@ -14,8 +14,8 @@ class Sync(Runner):
         self.TASK_CONFIG_INTERFACE = executor.TASK_CONFIG_INTERFACE
         self.queue = Queue()
 
-    def kill(self, *args):
-        pass
+    def kill(self, task_id):
+        self.executor.kill(task_id)
 
     def run(self, task_config):
         self.executor.run(task_config)

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -181,7 +181,7 @@ def test_reenqueue_tasks_stuck_in_unknown_state(
     )
     assert mock_get_metric.call_count == 1
     assert mock_get_metric.call_args == mock.call(
-        ef_mdl.TASK_LAUNCH_FAILED_COUNT
+        ef_mdl.TASK_FAILED_TO_LAUNCH_COUNT
     )
     assert mock_get_metric.return_value.count.call_count == 1
     assert mock_get_metric.return_value.count.call_args == mock.call(1)
@@ -473,12 +473,13 @@ def test_initialize_metrics(ef):
 
     ef._initialize_metrics()
 
-    assert ef_mdl.create_counter.call_count == 12
+    assert ef_mdl.create_counter.call_count == 13
     ef_mdl_counters = [
         ef_mdl.TASK_LAUNCHED_COUNT,
         ef_mdl.TASK_FINISHED_COUNT,
         ef_mdl.TASK_FAILED_COUNT,
         ef_mdl.TASK_LAUNCH_FAILED_COUNT,
+        ef_mdl.TASK_FAILED_TO_LAUNCH_COUNT,
         ef_mdl.TASK_KILLED_COUNT,
         ef_mdl.TASK_LOST_COUNT,
         ef_mdl.TASK_LOST_DUE_TO_INVALID_OFFER_COUNT,
@@ -589,7 +590,7 @@ def test_resource_offers_launch_tasks_failed(
     assert not ef.are_offers_suppressed
     assert fake_driver.declineOffer.call_count == 0
     assert fake_driver.launchTasks.call_count == 1
-    assert mock_get_metric.call_count == 0
+    assert mock_get_metric.call_count == 1
     assert ef.task_metadata[task_id].task_state == 'UNKNOWN'
 
 

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -1,3 +1,4 @@
+import socket
 import threading
 import time
 
@@ -151,6 +152,53 @@ def test_ef_kills_stuck_tasks(
     assert mock_get_metric.call_args == mock.call(ef_mdl.TASK_STUCK_COUNT)
     assert mock_get_metric.return_value.count.call_count == 1
     assert mock_get_metric.return_value.count.call_args == mock.call(1)
+
+
+def test_reenqueue_tasks_stuck_in_unknown_state(
+    ef,
+    fake_task,
+    mock_sleep,
+    mock_get_metric
+):
+    task_id = fake_task.task_id
+    task_metadata = ef_mdl.TaskMetadata(
+        agent_id='fake_agent_id',
+        task_config=fake_task,
+        task_state='UNKNOWN',
+        task_state_history=m(UNKNOWN=0.0),
+    )
+    ef.task_staging_timeout_s = 0
+    ef.kill_task = mock.Mock()
+    ef.blacklist_slave = mock.Mock()
+    ef._reenqueue_task = mock.Mock()
+
+    ef.task_metadata = ef.task_metadata.set(task_id, task_metadata)
+    ef.kill_tasks_stuck_in_staging()
+
+    assert ef._reenqueue_task.call_count == 1
+    assert ef._reenqueue_task.call_args == mock.call(task_id)
+    assert mock_get_metric.call_count == 1
+    assert mock_get_metric.call_args == mock.call(
+        ef_mdl.TASK_LAUNCH_FAILED_COUNT
+    )
+    assert mock_get_metric.return_value.count.call_count == 1
+    assert mock_get_metric.return_value.count.call_args == mock.call(1)
+
+
+def test_reenqueue_task(ef, fake_task):
+    task_id = fake_task.task_id
+    task_metadata = ef_mdl.TaskMetadata(
+        agent_id='fake_agent_id',
+        task_config=fake_task,
+        task_state='TASK_INITED',
+        task_state_history=m(TASK_INITED=0.0),
+    )
+    ef.task_metadata = ef.task_metadata.set(task_id, task_metadata)
+    ef.enqueue_task = mock.Mock()
+
+    ef._reenqueue_task(task_id)
+
+    ef.enqueue_task.call_count = 1
 
 
 def test_offer_matches_pool_no_pool(ef, fake_offer):
@@ -439,11 +487,12 @@ def test_initialize_metrics(ef):
 
     ef._initialize_metrics()
 
-    assert ef_mdl.create_counter.call_count == 11
+    assert ef_mdl.create_counter.call_count == 12
     ef_mdl_counters = [
         ef_mdl.TASK_LAUNCHED_COUNT,
         ef_mdl.TASK_FINISHED_COUNT,
         ef_mdl.TASK_FAILED_COUNT,
+        ef_mdl.TASK_LAUNCH_FAILED_COUNT,
         ef_mdl.TASK_KILLED_COUNT,
         ef_mdl.TASK_LOST_COUNT,
         ef_mdl.TASK_LOST_DUE_TO_INVALID_OFFER_COUNT,
@@ -522,6 +571,40 @@ def test_resource_offers_launch(
     assert mock_get_metric.return_value.record.call_args == mock.call(1.0)
     assert mock_get_metric.return_value.count.call_count == 1
     assert mock_get_metric.return_value.count.call_args == mock.call(1)
+
+
+def test_resource_offers_launch_tasks_failed(
+    ef,
+    fake_task,
+    fake_offer,
+    fake_driver,
+    mock_get_metric,
+    mock_time
+):
+    ef.driver = fake_driver
+    ef.driver.launchTasks = mock.Mock(side_effect=socket.timeout)
+    ef._last_offer_time = None
+    mock_time.return_value = 2.0
+    ef.suppress_after = 0.0
+    ef.offer_matches_pool = mock.Mock(return_value=True)
+    task_id = fake_task.task_id
+    docker_task = Dict(task_id=Dict(value=task_id))
+    task_metadata = ef_mdl.TaskMetadata(
+        task_config=fake_task,
+        task_state='fake_state',
+        task_state_history=m(fake_state=time.time())
+    )
+    ef.get_tasks_to_launch = mock.Mock(return_value=[docker_task])
+    ef.task_queue.put(fake_task)
+    ef.task_metadata = ef.task_metadata.set(task_id, task_metadata)
+    ef.resourceOffers(ef.driver, [fake_offer])
+
+    assert fake_driver.suppressOffers.call_count == 0
+    assert not ef.are_offers_suppressed
+    assert fake_driver.declineOffer.call_count == 0
+    assert fake_driver.launchTasks.call_count == 1
+    assert mock_get_metric.call_count == 0
+    assert ef.task_metadata[task_id].task_state == 'UNKNOWN'
 
 
 def test_get_tasks_to_launch_no_ports(


### PR DESCRIPTION
This PR is to deal with launchTasks failures. 
If launchTask() fails, then there 2 outcomes:
1) Mesos has received the task.
2) Mesos did not receive the task.

The current approach is to move the tasks into unknown state and reconcile their status periodically. If the tasks have been received by mesos, then it will return their current state. But, they were never received by mesos, then it is our responsibility to re-enqueue these tasks. 