### PR TITLE
stricter checks on task config cmd attribute

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+    /usr/*
+    /opt/*
+    .tox/*

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -38,15 +38,17 @@ def valid_volumes(volumes):
 
 
 class MesosTaskConfig(PRecord):
-    def __invariant__(conf): return ('image' in conf if conf.containerizer ==
-                                     'DOCKER' else True,
-                                     'Image required for chosen containerizer')
+    def __invariant__(conf):
+        return ('image' in conf if conf.containerizer == 'DOCKER' else True,
+                'Image required for chosen containerizer')
 
     uuid = field(type=uuid.UUID, initial=uuid.uuid4)
     name = field(type=str, initial="default")
     # image is optional for the mesos containerizer
     image = field(type=str)
-    cmd = field(type=str, initial="/bin/true")
+    cmd = field(type=str,
+                mandatory=True,
+                invariant=lambda cmd: (cmd.strip() != '', 'empty cmd'))
     cpus = field(type=float,
                  initial=0.1,
                  factory=float,

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -290,6 +290,7 @@ def test_get_tasks_to_launch_insufficient_offer(
 ):
     ef.create_new_docker_task = mock.Mock()
     task = me_mdl.MesosTaskConfig(
+        cmd='/bin/true',
         name='fake_name',
         image='fake_image',
         cpus=task_cpus,
@@ -659,7 +660,8 @@ def test_resource_offers_unmet_reqs(
 
 
 def status_update_test_prep(state, reason=''):
-    task = me_mdl.MesosTaskConfig(name='fake_name', image='fake_image')
+    task = me_mdl.MesosTaskConfig(
+        cmd='/bin/true', name='fake_name', image='fake_image')
     task_id = task.task_id
     update = Dict(
         task_id=Dict(value=task_id),

--- a/tests/unit/plugins/mesos/mesos_task_config_test.py
+++ b/tests/unit/plugins/mesos/mesos_task_config_test.py
@@ -2,7 +2,8 @@ from task_processing.plugins.mesos.mesos_executor import MesosTaskConfig
 
 
 def test_mesos_task_config_factories():
-    m = MesosTaskConfig(cpus=1, mem=64, disk=15, gpus=6.0, image='fake_image')
+    m = MesosTaskConfig(
+        cmd='/bin/true', cpus=1, mem=64, disk=15, gpus=6.0, image='fake_image')
 
     assert type(m.cpus) is float
     assert m.cpus == 1.0


### PR DESCRIPTION
- make cmd mandatory
- disallow empty cmd