### PR TITLE
Fixed the exception when an agent being blacklisted more than once

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -194,11 +194,8 @@ class ExecutionFramework(Scheduler):
 
     def blacklist_slave(self, agent_id, timeout):
         with self._lock:
-            if agent_id in self.blacklisted_slaves:
-                # Punish this slave for more time.
-                self.blacklisted_slaves = \
-                    self.blacklisted_slaves.remove(agent_id)
-
+            # A new entry is appended even if the agent is being blacklisted.
+            # This is equivalent to restarting the blacklist timer.
             log.info('Blacklisting slave: {id} for {secs} seconds.'.format(
                 id=agent_id,
                 secs=timeout

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -233,6 +233,9 @@ def test_blacklist_slave(
     assert mock_get_metric.return_value.count.call_count == 1
     assert mock_get_metric.return_value.count.call_args == mock.call(1)
 
+    for i in range(0, 2):
+        ef.blacklisted_slaves = ef.blacklisted_slaves.remove(agent_id)
+
 
 def test_unblacklist_slave(
     ef,


### PR DESCRIPTION
This fixes TASKPROC-129. 

Another way to fix it is to merge blacklisting with the background thread. I am keeping the original design to make the processing simple at the cost of one sleeping thread for each blacklisted agent.