### PR TITLE
Add retrying executor example and pass params on task_config

### DIFF
--- a/examples/retry.py
+++ b/examples/retry.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import logging
+
+from common import parse_args
+
+from task_processing.runners.sync import Sync
+from task_processing.task_processor import TaskProcessor
+
+FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
+LEVEL = logging.DEBUG
+logging.basicConfig(format=FORMAT, level=LEVEL)
+
+
+def main():
+    args = parse_args()
+    processor = TaskProcessor()
+    processor.load_plugin(provider_module='task_processing.plugins.mesos')
+    mesos_executor = processor.executor_from_config(
+        provider='mesos',
+        provider_config={
+            'secret': args.secret,
+            'mesos_address': args.master,
+            'pool': args.pool,
+            'role': args.role,
+        }
+    )
+
+    executor = processor.executor_from_config(
+        provider='retrying',
+        provider_config={
+            'downstream_executor': mesos_executor,
+        }
+    )
+
+    TaskConfig = mesos_executor.TASK_CONFIG_INTERFACE
+    runner = Sync(executor=executor)
+    task_config = TaskConfig(
+        image='docker-dev.yelpcorp.com/dumb-busybox',
+        cmd='/bin/false',
+        retries=5
+    )
+    result = runner.run(task_config)
+    print(result)
+
+    runner.stop()
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -68,6 +68,10 @@ class MesosTaskConfig(PRecord):
                     factory=float,
                     mandatory=False,
                     invariant=lambda t: (t > 0, 'timeout > 0'))
+    retries = field(type=int,
+                    factory=int,
+                    mandatory=False,
+                    invariant=lambda r: (r > 0, 'retries >= 0'))
     volumes = field(type=PVector,
                     initial=v(),
                     factory=pvector,

--- a/task_processing/plugins/stateful/stateful_executor.py
+++ b/task_processing/plugins/stateful/stateful_executor.py
@@ -47,7 +47,7 @@ class StatefulTaskExecutor(TaskExecutor):
             result = self.downstream_executor.get_event_queue().get()
             try:
                 self.persister.write(event=result)
-            except:
+            except Exception:
                 log.error(traceback.format_exc())
             self.queue_for_processed_events.put(result)
             self.downstream_executor.get_event_queue().task_done()

--- a/task_processing/runners/async.py
+++ b/task_processing/runners/async.py
@@ -61,7 +61,7 @@ class Async(Runner):
                     if cb.predicate(event):
                         try:
                             cb.cb(event)
-                        except:
+                        except Exception:
                             log.error(traceback.format_exc())
                             os._exit(1)
             except Empty:

--- a/tests/unit/plugins/mesos/retrying_executor_test.py
+++ b/tests/unit/plugins/mesos/retrying_executor_test.py
@@ -19,12 +19,12 @@ def mock_Thread():
 @pytest.fixture
 def mock_retrying_executor(mock_Thread):
     return RetryingExecutor(
-        executor=mock.Mock(),
+        downstream_executor=mock.Mock(),
     )
 
 
 def _get_mock_task_config():
-    return MesosTaskConfig(image='mock_image', cmd='mock_cmd')
+    return MesosTaskConfig(image='mock_image', cmd='mock_cmd', retries=5)
 
 
 def _get_mock_event(is_terminal=False):
@@ -45,7 +45,7 @@ def _get_mock_event(is_terminal=False):
 def test_task_retry(mock_retrying_executor):
     mock_event = _get_mock_event()
     mock_retrying_executor.task_retries = mock_retrying_executor.\
-        task_retries.set(mock_event.task_id, 1)
+        task_retries.set(mock_event.task_id, 3)
     mock_retrying_executor.run = mock.Mock()
 
     mock_retrying_executor.retry(mock_event)
@@ -57,13 +57,13 @@ def test_task_retry(mock_retrying_executor):
 def test_retries_exhaused(mock_retrying_executor):
     mock_event = _get_mock_event()
     mock_retrying_executor.task_retries = mock_retrying_executor.\
-        task_retries.set(mock_event.task_id, 3)
+        task_retries.set(mock_event.task_id, 1)
     mock_retrying_executor.run = mock.Mock()
 
     mock_retrying_executor.retry(mock_event)
 
-    assert mock_retrying_executor.task_retries[mock_event.task_id] == 3
-    assert mock_retrying_executor.run.call_count == 0
+    assert mock_retrying_executor.task_retries[mock_event.task_id] == 0
+    assert mock_retrying_executor.run.call_count == 1
 
 
 def test_task_config_with_retry(mock_retrying_executor):


### PR DESCRIPTION
Add retrying executor at examples/retry.py

Modify retrying executor to allow user passing params through task_config like this:
task_config = TaskConfig(
        image='docker-dev.yelpcorp.com/dumb-busybox',
        cmd='/bin/false',
        retries=5,
        retry_pred='lambda e: not e.success'
    )

Manually testing by command 
"docker-compose -f examples/cluster/docker-compose.yaml run playground examples/retry.py"