### PR TITLE
Fixed retry logging and retries counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Interfaces and shared infrastructure for generic task processing (also known as 
 This will bring up a single master, single agent Mesos cluster using [Docker Compose](https://docs.docker.com/compose/) and launch a single task which will print "hello world" to the sandbox's stdout before terminating.
 
 Other examples available include:
-+ async  
++ async.py
 Example of the [async](#async) task runner.
 
 + dynamo_persistence.py  
-Example that shows how task events may be persisted to [DynamoDB](https://aws.amazon.com/dynamodb) using the `stateful` plugin..
+Example that shows how task events may be persisted to [DynamoDB](https://aws.amazon.com/dynamodb) using the `stateful` plugin.
 
 + file_persistence.py  
 Example that shows how task events may be persisted to disk using the `stateful` plugin.
@@ -38,6 +38,12 @@ Example of the [subscription](#subscription) task runner.
 
 + sync.py  
 Brief example using the [sync](#sync) task runner.
+
++ timeout.py
+Example that shows how to timeout a task execution using the `timeout` plugin.
+
++ retry.py
+Example that shows how to retry a task on failure using the `retry` plugin.
 
 ### Running tests
 
@@ -57,9 +63,16 @@ From the root of the repository, run:
 
 ### /plugins
 
-#### Mesos
+Plugins can be chained to create a task execution pipeline with more than one property. Please refer to persistence/retry/timeout examples.
 
+#### mesos
 Implements all required interfaces to talk to Mesos deployment. This plugin uses [PyMesos](https://github.com/douban/pymesos) to communicate with Mesos.
+
+#### timeout
+Implements an executor to timeout task execution.
+
+#### retrying
+Implements an executor to retry task execution upon failure.
 
 ##### Configuration options
 

--- a/examples/retry.py
+++ b/examples/retry.py
@@ -37,7 +37,7 @@ def main():
     task_config = TaskConfig(
         image='docker-dev.yelpcorp.com/dumb-busybox',
         cmd='/bin/false',
-        retries=5
+        retries=2
     )
     result = runner.run(task_config)
     print(result)

--- a/examples/timeout.py
+++ b/examples/timeout.py
@@ -37,7 +37,7 @@ def main():
     task_config = TaskConfig(
         image='docker-dev.yelpcorp.com/dumb-busybox',
         cmd='exec dumb-init /bin/sleep 30',
-        timeout=15
+        timeout=10
     )
     result = runner.run(task_config)
     print(result)

--- a/itest
+++ b/itest
@@ -7,6 +7,8 @@ examples/file_persistence.py
 examples/hello-world.py
 examples/subscription.py
 examples/sync.py
+examples/retry.py
+examples/timeout.py
 
 # TODO: These should probably also be run eventually:
 # examples/promise.py

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -68,10 +68,12 @@ class MesosTaskConfig(PRecord):
                     factory=float,
                     mandatory=False,
                     invariant=lambda t: (t > 0, 'timeout > 0'))
+    # By default, the retrying executor retries 3 times. This task option
+    # overrides the executor setting.
     retries = field(type=int,
                     factory=int,
                     mandatory=False,
-                    invariant=lambda r: (r > 0, 'retries >= 0'))
+                    invariant=lambda r: (r >= 0, 'retries >= 0'))
     volumes = field(type=PVector,
                     initial=v(),
                     factory=pvector,


### PR DESCRIPTION
1. Fix incorrect retrying log message
2. Make the field "retries" truly the number of retries, not the total number of runs (retries+1).