### PR TITLE
Added an option to capture remote task logs

### DIFF
--- a/examples/sync.py
+++ b/examples/sync.py
@@ -27,6 +27,12 @@ def main():
 
     TaskConfig = executor.TASK_CONFIG_INTERFACE
     task_config = TaskConfig(image="busybox", cmd='/bin/true')
+    # Test log fetching
+    # task_config = TaskConfig(
+    #     image="ubuntu:14.04",
+    #     task_log=True,
+    #     cmd="bash -c 'for i in $(seq 1 30); do echo $i&&sleep 10; done'"
+    # )
     # This only works on agents that have added mesos as a containerizer
     # task_config = TaskConfig(containerizer='MESOS', cmd='/bin/true')
 

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -78,6 +78,8 @@ class MesosTaskConfig(PRecord):
                     initial=v(),
                     factory=pvector,
                     invariant=valid_volumes)
+    task_log = field(type=bool, initial=False, mandatory=False)
+
     ports = field(type=PVector, initial=v(), factory=pvector)
     cap_add = field(type=PVector, initial=v(), factory=pvector)
     ulimit = field(type=PVector, initial=v(), factory=pvector)

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -79,7 +79,14 @@ def fake_offer():
                 name='pool',
                 text=Dict(value='fake_pool_text')
             )
-        ]
+        ],
+        url=Dict(
+            address=Dict(
+                ip='1.2.3.4',
+                port=5051,
+            ),
+            scheme='http',
+        ),
     )
 
 


### PR DESCRIPTION
This is TASKPROC-127. 

- I wish I could use mesos-cli to hit the mesos files/read endpoint. However, this would create a circular dependency between paasta and taskproc.
- I chose to fetch task log in the framework scheduler instead of in an executor plugin because I feel logging is part of the remote execution.
- I chose to use the single background thread to fetch logs periodically instead of downloading the whole log at the end to avoid a one time spike on the mesos API. One thread per task is not used because it will mess up output.