### PR TITLE
Only fetch the last piece of logs when the task is active

### DIFF
--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -164,10 +164,11 @@ class MesosLoggingExecutor(TaskExecutor):
                             )
                         )
 
-                # Fetch the last log and remove the entry
+                # Fetch the last log and remove the entry if the task is active
                 if e.kind == 'task' and e.terminal:
                     with self.task_lock:
-                        self.done_tasks = self.done_tasks.append(e.task_id)
+                        if e.task_id in self.running_tasks:
+                            self.done_tasks = self.done_tasks.append(e.task_id)
 
             if self.stopping:
                 return


### PR DESCRIPTION
TASKPORC-155 happened because the logging executor trying to fetch the last piece of log while the task was never added to the running_task map.  