### PR TITLE
Support offer timeout

### DIFF
--- a/examples/offer_timeout.py
+++ b/examples/offer_timeout.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import logging
+import time
+
+from common import parse_args
+
+from task_processing.runners.async import Async
+from task_processing.runners.async import EventHandler
+from task_processing.task_processor import TaskProcessor
+
+FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
+LEVEL = logging.DEBUG
+logging.basicConfig(format=FORMAT, level=LEVEL)
+
+
+class Counter(object):
+    def __init__(self):
+        self.terminated = 0
+
+    def process_event(self, event):
+        print("task %s finished" % (event.task_id))
+        self.terminated += 1
+
+
+def main():
+    c = Counter()
+    args = parse_args()
+    processor = TaskProcessor()
+    processor.load_plugin(provider_module='task_processing.plugins.mesos')
+    mesos_executor = processor.executor_from_config(
+        provider='mesos',
+        provider_config={
+            'secret': args.secret,
+            'mesos_address': args.master,
+            'pool': args.pool,
+            'role': args.role,
+        }
+    )
+
+    TaskConfig = mesos_executor.TASK_CONFIG_INTERFACE
+    runner = Async(
+        mesos_executor,
+        [EventHandler(
+            predicate=lambda x: x.terminal,
+            cb=c.process_event,
+        )]
+    )
+    timeout_task_config = TaskConfig(
+        image='busybox',
+        cmd='exec /bin/sleep 100',
+        offer_timeout=5.0,
+        cpus=20,
+        mem=2048,
+        disk=2000,
+    )
+    runner.run(timeout_task_config)
+
+    for _ in range(50):
+        if c.terminated >= 1:
+            break
+        print("waiting for task %s to finish" % (timeout_task_config.task_id))
+        time.sleep(2)
+
+    runner.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -1,100 +1,17 @@
 import logging
 import threading
-import uuid
 
 from pymesos import MesosSchedulerDriver
-from pyrsistent import field
-from pyrsistent import m
-from pyrsistent import PMap
-from pyrsistent import pmap
-from pyrsistent import PRecord
-from pyrsistent import PVector
-from pyrsistent import pvector
-from pyrsistent import v
 
 from task_processing.interfaces.task_executor import TaskExecutor
 from task_processing.plugins.mesos.execution_framework import (
     ExecutionFramework
 )
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
 from task_processing.plugins.mesos.translator import mesos_status_to_event
 
 FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
 logging.basicConfig(format=FORMAT)
-
-
-VOLUME_KEYS = set(['mode', 'container_path', 'host_path'])
-
-
-def valid_volumes(volumes):
-    for vol in volumes:
-        if set(vol.keys()) != VOLUME_KEYS:
-            return (
-                False,
-                'Invalid volume format, must only contain following keys: '
-                '{}, was: {}'.format(VOLUME_KEYS, vol.keys())
-            )
-    return (True, None)
-
-
-class MesosTaskConfig(PRecord):
-    def __invariant__(conf):
-        return ('image' in conf if conf.containerizer == 'DOCKER' else True,
-                'Image required for chosen containerizer')
-
-    uuid = field(type=(str, uuid.UUID), initial=uuid.uuid4)
-    name = field(type=str, initial="default")
-    # image is optional for the mesos containerizer
-    image = field(type=str)
-    cmd = field(type=str,
-                mandatory=True,
-                invariant=lambda cmd: (cmd.strip() != '', 'empty cmd'))
-    cpus = field(type=float,
-                 initial=0.1,
-                 factory=float,
-                 invariant=lambda c: (c > 0, 'cpus > 0'))
-    mem = field(type=float,
-                initial=32.0,
-                factory=float,
-                invariant=lambda m: (m >= 32, 'mem is >= 32'))
-    disk = field(type=float,
-                 initial=10.0,
-                 factory=float,
-                 invariant=lambda d: (d > 0, 'disk > 0'))
-    gpus = field(type=int,
-                 initial=0,
-                 factory=int,
-                 invariant=lambda g: (g >= 0, 'gpus >= 0'))
-    timeout = field(type=float,
-                    factory=float,
-                    mandatory=False,
-                    invariant=lambda t: (t > 0, 'timeout > 0'))
-    # By default, the retrying executor retries 3 times. This task option
-    # overrides the executor setting.
-    retries = field(type=int,
-                    factory=int,
-                    mandatory=False,
-                    invariant=lambda r: (r >= 0, 'retries >= 0'))
-    volumes = field(type=PVector,
-                    initial=v(),
-                    factory=pvector,
-                    invariant=valid_volumes)
-    ports = field(type=PVector, initial=v(), factory=pvector)
-    cap_add = field(type=PVector, initial=v(), factory=pvector)
-    ulimit = field(type=PVector, initial=v(), factory=pvector)
-    uris = field(type=PVector, initial=v(), factory=pvector)
-    # TODO: containerization + containerization_args ?
-    docker_parameters = field(type=PVector, initial=v(), factory=pvector)
-    containerizer = field(type=str,
-                          initial='DOCKER',
-                          invariant=lambda c:
-                          (c == 'DOCKER' or c == 'MESOS',
-                           'containerizer is docker or mesos'))
-    environment = field(type=PMap, initial=m(), factory=pmap)
-
-    @property
-    def task_id(self):
-        return "{}.{}".format(self.name, self.uuid)
-
 
 class MesosExecutor(TaskExecutor):
     TASK_CONFIG_INTERFACE = MesosTaskConfig

--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -71,6 +71,12 @@ class MesosTaskConfig(PRecord):
                           (c == 'DOCKER' or c == 'MESOS',
                            'containerizer is docker or mesos'))
     environment = field(type=PMap, initial=m(), factory=pmap)
+    offer_timeout = field(
+        type=float,
+        factory=float,
+        mandatory=False,
+        invariant=lambda t: (t > 0, 'timeout > 0')
+    )
 
     @property
     def task_id(self):

--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -1,0 +1,77 @@
+import uuid
+
+from pyrsistent import field
+from pyrsistent import m
+from pyrsistent import PMap
+from pyrsistent import pmap
+from pyrsistent import PRecord
+from pyrsistent import PVector
+from pyrsistent import pvector
+from pyrsistent import v
+
+VOLUME_KEYS = set(['mode', 'container_path', 'host_path'])
+
+
+def valid_volumes(volumes):
+    for vol in volumes:
+        if set(vol.keys()) != VOLUME_KEYS:
+            return (
+                False,
+                'Invalid volume format, must only contain following keys: '
+                '{}, was: {}'.format(VOLUME_KEYS, vol.keys())
+            )
+    return (True, None)
+
+
+class MesosTaskConfig(PRecord):
+    def __invariant__(conf):
+        return ('image' in conf if conf.containerizer == 'DOCKER' else True,
+                'Image required for chosen containerizer')
+
+    uuid = field(type=(str, uuid.UUID), initial=uuid.uuid4)
+    name = field(type=str, initial="default")
+    # image is optional for the mesos containerizer
+    image = field(type=str)
+    cmd = field(type=str,
+                mandatory=True,
+                invariant=lambda cmd: (cmd.strip() != '', 'empty cmd'))
+    cpus = field(type=float,
+                 initial=0.1,
+                 factory=float,
+                 invariant=lambda c: (c > 0, 'cpus > 0'))
+    mem = field(type=float,
+                initial=32.0,
+                factory=float,
+                invariant=lambda m: (m >= 32, 'mem is >= 32'))
+    disk = field(type=float,
+                 initial=10.0,
+                 factory=float,
+                 invariant=lambda d: (d > 0, 'disk > 0'))
+    gpus = field(type=int,
+                 initial=0,
+                 factory=int,
+                 invariant=lambda g: (g >= 0, 'gpus >= 0'))
+    timeout = field(type=float,
+                    factory=float,
+                    mandatory=False,
+                    invariant=lambda t: (t > 0, 'timeout > 0'))
+    volumes = field(type=PVector,
+                    initial=v(),
+                    factory=pvector,
+                    invariant=valid_volumes)
+    ports = field(type=PVector, initial=v(), factory=pvector)
+    cap_add = field(type=PVector, initial=v(), factory=pvector)
+    ulimit = field(type=PVector, initial=v(), factory=pvector)
+    uris = field(type=PVector, initial=v(), factory=pvector)
+    # TODO: containerization + containerization_args ?
+    docker_parameters = field(type=PVector, initial=v(), factory=pvector)
+    containerizer = field(type=str,
+                          initial='DOCKER',
+                          invariant=lambda c:
+                          (c == 'DOCKER' or c == 'MESOS',
+                           'containerizer is docker or mesos'))
+    environment = field(type=PMap, initial=m(), factory=pmap)
+
+    @property
+    def task_id(self):
+        return "{}.{}".format(self.name, self.uuid)


### PR DESCRIPTION
adds a per-task offer timeout.

I also moved the mesos task config into its own module, since it was bugging me how big execution_framework was getting (I've got more for this, but its a start)