### PR TITLE
Pool per task

### DIFF
--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -109,6 +109,7 @@ class MesosTaskConfig(PRecord):
                                               value=v[2]) for v in c)),
         invariant=_valid_constraints,
     )
+    pool = field(type=(str, type(None)), initial=None)
 
     @property
     def task_id(self):


### PR DESCRIPTION
Allow specifying pool per task in addition or instead of specifying a pool for the executor.
If a task has a pool then the pool is used while matching an offer to the task, otherwise a pool from the executor is used while matching an offer to the task.
