### PR TITLE
Set `offer_timeout` to 60sec by default to prevent an exception

### DIFF
--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -98,8 +98,8 @@ class MesosTaskConfig(PRecord):
     environment = field(type=PMap, initial=m(), factory=pmap)
     offer_timeout = field(
         type=float,
+        initial=60.0,
         factory=float,
-        mandatory=False,
         invariant=lambda t: (t > 0, 'timeout > 0')
     )
     constraints = field(


### PR DESCRIPTION
Set default value for `offer_timeout` to 60 seconds to prevent errors like
```
Exception in thread Thread-1:                                  
Traceback (most recent call last):                             
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/pyrsistent/_pmap.py", line 92, in __getattr__                     
    return self[key]                                           
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/pyrsistent/_pmap.py", line 68, in __getitem__                     
    return PMap._getitem(self._buckets, key)                   
  File "/opt/venvs/paasta-tools/lib/python3.6/site-packages/pyrsistent/_pmap.py", line 65, in _getitem                        
    raise KeyError(key)                                        
KeyError: 'offer_timeout'
```
While here, let's remove `mandatory=False` for `offer_timeout` aswell, as ["Fields are not mandatory by default"](https://github.com/tobgu/pyrsistent#mandatory-fields).