### PR TITLE
fix couple issues with events missing required attributes

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -157,7 +157,8 @@ class ExecutionFramework(Scheduler):
                                     terminal=True,
                                     timestamp=time.time(),
                                     success=False,
-                                    message='stop'
+                                    message='stop',
+                                    task_config=md.task_config,
                                 ))
                             get_metric(TASK_OFFER_TIMEOUT).count(1)
 

--- a/task_processing/plugins/mesos/retrying_executor.py
+++ b/task_processing/plugins/mesos/retrying_executor.py
@@ -66,6 +66,11 @@ class RetryingExecutor(TaskExecutor):
         while True:
             while not self.src_queue.empty():
                 e = self.src_queue.get()
+
+                if e.kind != 'task':
+                    self.dest_queue.put(e)
+                    continue
+
                 # This is to remove trailing '-retry*'
                 original_task_id = '-'.join([item for item in
                                              e.task_id.split('-')[:-1]])
@@ -77,10 +82,6 @@ class RetryingExecutor(TaskExecutor):
 
                 # Set the task id back to original task_id
                 e = self._restore_task_id(e, original_task_id)
-
-                if e.kind != 'task':
-                    self.dest_queue.put(e)
-                    continue
 
                 e = self.event_with_retries(e)
 

--- a/tests/unit/plugins/mesos/retrying_executor_test.py
+++ b/tests/unit/plugins/mesos/retrying_executor_test.py
@@ -194,3 +194,24 @@ def test_retry_loop_does_not_retry_task(mock_retrying_executor):
 
     assert mock_retrying_executor.dest_queue.qsize() == 1
     assert len(mock_retrying_executor.task_retries) == 0
+
+
+def test_retry_loop_filters_out_non_task(mock_retrying_executor):
+    mock_event = Event(
+        kind='control',
+        raw='some message',
+        message='stop',
+        terminal=True
+    )
+
+    mock_retrying_executor.stopping = True
+    mock_retrying_executor._is_current_attempt = mock.Mock(return_value=True)
+    mock_retrying_executor.event_with_retries = mock.Mock()
+    mock_retrying_executor.retry = mock.Mock(return_value=True)
+    mock_retrying_executor.retry_pred = mock.Mock(return_value=True)
+    mock_retrying_executor.src_queue = Queue()
+    mock_retrying_executor.src_queue.put(mock_event)
+
+    mock_retrying_executor.retry_loop()
+
+    assert mock_retrying_executor.dest_queue.qsize() == 1


### PR DESCRIPTION
- pass task config in offer timeout event
- move kind=task filter in retrying executor to the top of the loop