### PR TITLE
add global event invariant

### DIFF
--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -16,7 +16,7 @@ EVENT_TASK_ATTRS = {'task_id', 'task_config'}
 class Event(PRecord):
 
     @staticmethod
-    def validate_task(r):
+    def validate_task_event(r):
         if r.kind != 'task':
             return True, 'Not a task event'
 
@@ -27,7 +27,7 @@ class Event(PRecord):
         return True, 'Task is valid'
 
     def __invariant__(r): return (
-        Event.validate_task(r),
+        Event.validate_task_event(r),
     )
 
     kind = field(type=str,

--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -9,10 +9,27 @@ from pyrsistent import pmap
 from pyrsistent import PRecord
 
 
-EVENT_KINDS = ['task', 'control']
+EVENT_KINDS = {'task', 'control'}
+EVENT_TASK_ATTRS = {'task_id', 'task_config'}
 
 
 class Event(PRecord):
+
+    @staticmethod
+    def validate_task(r):
+        if r.kind != 'task':
+            return True, 'Not a task event'
+
+        missing_attrs = EVENT_TASK_ATTRS - set(r.keys())
+        if missing_attrs:
+            return False, 'Missing task attributes: {}'.format(missing_attrs)
+
+        return True, 'Task is valid'
+
+    def __invariant__(r): return (
+        Event.validate_task(r),
+    )
+
     kind = field(type=str,
                  mandatory=True,
                  invariant=lambda x: (x in EVENT_KINDS,

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -674,8 +674,9 @@ class ExecutionFramework(Scheduler):
                             offer=offer,
                         )
                         self.event_queue.put(
-                            self.translator(update, task.task_id.value).set(
-                                task_config=md.task_config
+                            self.translator(
+                                update, task.task_id.value,
+                                task_config=md.task_config,
                             )
                         )
                         get_metric(TASK_LAUNCHED_COUNT).count(1)
@@ -740,8 +741,7 @@ class ExecutionFramework(Scheduler):
                 )
 
             self.event_queue.put(
-                self.translator(update, task_id).set(
-                    task_config=md.task_config)
+                self.translator(update, task_id, task_config=md.task_config)
             )
 
             if task_state in self._terminal_task_counts:

--- a/task_processing/plugins/mesos/translator.py
+++ b/task_processing/plugins/mesos/translator.py
@@ -5,43 +5,42 @@ from task_processing.interfaces.event import task_event
 # https://github.com/apache/mesos/blob/master/include/mesos/mesos.proto
 
 MESOS_STATUS_MAP = {
-    'TASK_STARTING': task_event(platform_type='starting', terminal=False),
-    'TASK_RUNNING': task_event(platform_type='running', terminal=False),
-    'TASK_FINISHED': task_event(platform_type='finished',
-                                terminal=True,
-                                success=True),
-    'TASK_FAILED': task_event(platform_type='failed',
-                              terminal=True,
-                              success=False),
-    'TASK_KILLED': task_event(platform_type='killed',
-                              terminal=True,
-                              success=False),
-    'TASK_LOST': task_event(platform_type='lost',
-                            terminal=True,
-                            success=False),
-    'TASK_STAGING': task_event(platform_type='staging', terminal=False),
-    'TASK_ERROR': task_event(platform_type='error',
-                             terminal=True,
-                             success=False),
-    'TASK_KILLING': task_event(platform_type='killing', terminal=False),
-    'TASK_DROPPED': task_event(platform_type='dropped',
-                               terminal=True,
-                               success=False),
-    'TASK_UNREACHABLE': task_event(platform_type='unreachable',
-                                   terminal=False),
-    'TASK_GONE': task_event(platform_type='gone',
-                            terminal=True,
-                            success=False),
-    'TASK_GONE_BY_OPERATOR': task_event(platform_type='gone_by_operator',
-                                        terminal=True,
-                                        success=False),
-    'TASK_UNKNOWN': task_event(platform_type='unknown', terminal=False)
+    'TASK_STARTING':
+    dict(platform_type='starting', terminal=False),
+    'TASK_RUNNING':
+    dict(platform_type='running', terminal=False),
+    'TASK_FINISHED':
+    dict(platform_type='finished', terminal=True, success=True),
+    'TASK_FAILED':
+    dict(platform_type='failed', terminal=True, success=False),
+    'TASK_KILLED':
+    dict(platform_type='killed', terminal=True, success=False),
+    'TASK_LOST':
+    dict(platform_type='lost', terminal=True, success=False),
+    'TASK_STAGING':
+    dict(platform_type='staging', terminal=False),
+    'TASK_ERROR':
+    dict(platform_type='error', terminal=True, success=False),
+    'TASK_KILLING':
+    dict(platform_type='killing', terminal=False),
+    'TASK_DROPPED':
+    dict(platform_type='dropped', terminal=True, success=False),
+    'TASK_UNREACHABLE':
+    dict(platform_type='unreachable', terminal=False),
+    'TASK_GONE':
+    dict(platform_type='gone', terminal=True, success=False),
+    'TASK_GONE_BY_OPERATOR':
+    dict(platform_type='gone_by_operator', terminal=True, success=False),
+    'TASK_UNKNOWN':
+    dict(platform_type='unknown', terminal=False)
 }
 
 
-def mesos_status_to_event(mesos_status, task_id):
-    return MESOS_STATUS_MAP[mesos_status.state].set(
+def mesos_status_to_event(mesos_status, task_id, **kwargs):
+    return task_event(
         raw=mesos_status,
         task_id=str(task_id),
         timestamp=time.time(),
+        **MESOS_STATUS_MAP[mesos_status.state],
+        **kwargs,
     )

--- a/tests/unit/interfaces/event_test.py
+++ b/tests/unit/interfaces/event_test.py
@@ -8,12 +8,13 @@ from task_processing.interfaces.event import Event
 
 @pytest.fixture
 def event():
-    return Event(kind='task')
+    return Event(kind='task', task_id="123", task_config={})
 
 
 def test_event_creation():
     x = object()
-    e = Event(kind='task', raw=x, terminal=True, platform_type='killed')
+    e = Event(kind='task', task_id="123", task_config={},
+              raw=x, terminal=True, platform_type='killed')
     assert e.raw == x
     assert e.terminal
     assert e.platform_type == 'killed'

--- a/tests/unit/plugins/mesos/translator_test.py
+++ b/tests/unit/plugins/mesos/translator_test.py
@@ -9,4 +9,7 @@ def test_translator_maps_status_to_event():
     for k in MESOS_STATUS_MAP:
         mesos_status = MagicMock()
         mesos_status.state = k
-        assert isinstance(mesos_status_to_event(mesos_status, 123), Event)
+        assert isinstance(
+            mesos_status_to_event(mesos_status, 123, task_config={}),
+            Event,
+        )

--- a/tests/unit/plugins/persistence/dynamo_persistence_test.py
+++ b/tests/unit/plugins/persistence/dynamo_persistence_test.py
@@ -54,6 +54,7 @@ texts = st.text(max_size=5)
 events = st.builds(
     Event,
     kind=st.sampled_from(['task', 'control']),
+    task_id=texts,
     timestamp=st.floats(min_value=0, allow_nan=False, allow_infinity=False),
     terminal=st.booleans(),
     success=st.booleans(),


### PR DESCRIPTION
When event kind is 'task', we need to make a subset of attributes mandatory, which is not possible to do with per-field invariants.