### PR TITLE
task config id length invariant

### DIFF
--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -44,8 +44,16 @@ def _valid_constraints(constraints):
 
 class MesosTaskConfig(PRecord):
     def __invariant__(conf):
-        return ('image' in conf if conf.containerizer == 'DOCKER' else True,
-                'Image required for chosen containerizer')
+        return (
+            (
+                'image' in conf if conf.containerizer == 'DOCKER' else True,
+                'Image required for chosen containerizer',
+            ),
+            (
+                len(conf.task_id) <= 255,
+                'task_id is longer than 255 chars: {}'.format(conf.task_id)
+            ),
+        )
 
     uuid = field(type=(str, uuid.UUID), initial=uuid.uuid4)
     name = field(type=str, initial="default")

--- a/tests/unit/plugins/mesos/mesos_task_config_test.py
+++ b/tests/unit/plugins/mesos/mesos_task_config_test.py
@@ -1,3 +1,5 @@
+from pyrsistent import InvariantException
+
 from task_processing.plugins.mesos.mesos_executor import MesosTaskConfig
 
 
@@ -16,3 +18,10 @@ def test_mesos_task_config_factories():
 
     assert type(m.gpus) is int
     assert m.gpus == 6
+
+    try:
+        m = m.set(name='a'*256)
+        assert False, 'Task id longer than 255 characters was accepted'
+    except InvariantException as e:
+        print(e)
+        assert True


### PR DESCRIPTION
fail when trying to create task config with id >255 chars