### PR TITLE
Add option for logging executor to use python logging

### DIFF
--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -24,6 +24,7 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 TASK_LOG_CHUNK_LEN = 4096
 DEFAULT_FORMAT = '{task_id}[{container_id}@{agent}]: {line}'
 
+
 class LogMetadata(PRecord):
     log_url = field(type=str, initial='')
     log_path = field(type=str, initial='')
@@ -37,17 +38,18 @@ class LogMetadata(PRecord):
 def standard_handler(task_id, message, stream):
     print(message, file=sys.stderr if stream is 'stderr' else sys.stdout)
 
+
 class MesosLoggingExecutor(TaskExecutor):
     def __init__(
         self,
         downstream_executor,
-        handler=None,
-        format_string=None,
+        handler=standard_handler,
+        format_string=DEFAULT_FORMAT,
     ):
         self.downstream_executor = downstream_executor
         self.TASK_CONFIG_INTERFACE = downstream_executor.TASK_CONFIG_INTERFACE
-        self.handler = handler or standard_handler
-        self.format_string = format_string or DEFAULT_FORMAT
+        self.handler = handler
+        self.format_string = format_string
 
         self.src_queue = downstream_executor.get_event_queue()
         self.dest_queue = Queue()

--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -22,7 +22,11 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 # Read task log in 4K chunks
 TASK_LOG_CHUNK_LEN = 4096
-
+DESTINATIONS = {
+    'standard',  # stdout/stderr
+    'python',  # Python logging
+}
+DEFAULT_FORMAT = '{task_id}[{container_id}@{agent}]: {line}'
 
 class LogMetadata(PRecord):
     log_url = field(type=str, initial='')
@@ -35,8 +39,17 @@ class LogMetadata(PRecord):
 
 
 class MesosLoggingExecutor(TaskExecutor):
-    def __init__(self, downstream_executor):
+    def __init__(
+        self,
+        downstream_executor,
+        destination='standard',
+        name=None,
+        format_string=None,
+    ):
         self.downstream_executor = downstream_executor
+        self.TASK_CONFIG_INTERFACE = downstream_executor.TASK_CONFIG_INTERFACE
+        self.name = name or (__name__ + '.tasks')
+        self.format_string = format_string or DEFAULT_FORMAT
 
         self.src_queue = downstream_executor.get_event_queue()
         self.dest_queue = Queue()
@@ -45,6 +58,7 @@ class MesosLoggingExecutor(TaskExecutor):
         self.staging_tasks = m()
         self.running_tasks = m()
         self.done_tasks = v()
+        self.setup_loggers(destination)
 
         # A lock is needed to synchronize logging and event processing
         self.task_lock = Lock()
@@ -56,6 +70,45 @@ class MesosLoggingExecutor(TaskExecutor):
         self.logging_thread = Thread(target=self.logging_loop)
         self.logging_thread.daemon = True
         self.logging_thread.start()
+
+    def setup_loggers(self, destination):
+        if destination not in DESTINATIONS:
+            log.warning(
+                'Logging destination {dest} not supported, '
+                'using stdout/err'.format(destination)
+            )
+            destination = 'standard'
+        if destination == 'python':
+            self.task_loggers = m()
+        self.destination = destination
+
+    def setup_task_logger(self, task_id):
+        if self.destination == 'python':
+            if task_id not in self.task_loggers:
+                self.task_loggers = self.task_loggers.set(task_id, {
+                    'stderr': logging.getLogger('{}.{}.{}'.format(self.name, task_id, 'stderr')),
+                    'stdout': logging.getLogger('{}.{}.{}'.format(self.name, task_id, 'stdout')),
+                })
+
+    def cleanup_task_logger(self, task_id):
+        if self.destination == 'python':
+            self.task_loggers = self.task_loggers.discard(task_id)
+
+    def log_line(self, stream, line, task_id, container_id, agent):
+        self.setup_task_logger(task_id)
+        formatted_line = self.format_string.format(
+            task_id=task_id,
+            container_id=container_id,
+            agent=agent,
+            line=line,
+        )
+        if self.destination == 'standard':
+            print(
+                formatted_line,
+                file=sys.stderr if stream is 'stderr' else sys.stdout,
+            )
+        elif self.destination == 'python':
+            self.task_loggers[task_id][stream].info(formatted_line)
 
     def set_task_log_path(self, task_id):
         log_md = self.running_tasks[task_id]
@@ -106,10 +159,12 @@ class MesosLoggingExecutor(TaskExecutor):
 
                     log_length = len(response['data'])
                     for line in response['data'].splitlines():
-                        print(
-                            task_id + "[" + log_md.container_id +
-                            "@" + agent + "]: " + line,
-                            file=sys.stderr if f is 'stderr' else sys.stdout
+                        self.log_line(
+                            stream=f,
+                            line=line,
+                            task_id=task_id,
+                            container_id=log_md.container_id,
+                            agent=agent,
                         )
                 except Exception as e:
                     log.error("Failed to get {path}@{agent} {error}".format(
@@ -187,6 +242,7 @@ class MesosLoggingExecutor(TaskExecutor):
                 with self.task_lock:
                     self.done_tasks = self.done_tasks.remove(task_id)
                     self.running_tasks = self.running_tasks.discard(task_id)
+                    self.cleanup_task_logger(task_id)
 
             if self.stopping:
                 return

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -13,6 +13,7 @@ from task_processing.plugins.mesos.translator import mesos_status_to_event
 FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
 logging.basicConfig(format=FORMAT)
 
+
 class MesosExecutor(TaskExecutor):
     TASK_CONFIG_INTERFACE = MesosTaskConfig
 


### PR DESCRIPTION
I want to be able to direct messages for each task to a different file, and Python logging seems like the best way to do that. Here's an idea for how to add that functionality to the logging executor.

Very open to other ideas on how to achieve this. Maybe it would be better to create subclasses of LoggingExecutor that implement setup_loggers, etc?

