### PR TITLE
clean up dev/tox/etc, strip out six (we only support 3.6 from now on)

### DIFF
--- a/.activate.sh
+++ b/.activate.sh
@@ -1,0 +1,1 @@
+venv/bin/activate

--- a/.deactivate.sh
+++ b/.deactivate.sh
@@ -1,0 +1,1 @@
+deactivate

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ ENV/
 
 # Vim
 *.sw[nop]
+
+.pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test dev_env docs
+.PHONY: all test dev_env docs venv pypi
 
 TOX=".tox/dev/bin/tox"
 
@@ -8,6 +8,9 @@ ifeq ($(findstring .yelpcorp.com, $(shell hostname -f)), .yelpcorp.com)
 else
 	BUILD_ENV?=$(shell hostname -f)
 endif
+
+venv:
+	tox -e venv
 
 test: dev_env
 	${TOX}
@@ -36,3 +39,4 @@ clean:
 	rm -rf .tox .taskproc
 	rm -rf dist build
 	rm -rf task_processing.egg-info
+	rm -rf venv

--- a/examples/cluster/docker-compose.yaml
+++ b/examples/cluster/docker-compose.yaml
@@ -42,7 +42,6 @@ services:
       - mesosagent
       - dynamodb
     volumes:
-      - ../..:/src
       - /var/run/docker.sock:/var/run/docker.sock
   dynamodb:
     image: deangiberson/aws-dynamodb-local

--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -1,12 +1,17 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        software-properties-common \
         debhelper dpkg-dev gcc gdebi-core git help2man libffi-dev \
         libssl-dev libsasl2-modules libyaml-dev pyflakes python3-dev python3-pip python3-pytest \
         python-tox python-yaml wget zip zsh \
         openssh-server docker.io curl vim jq libsvn-dev \
     && apt-get clean
+
+RUN add-apt-repository ppa:jonathonf/python-3.6 
+RUN apt-get update -q && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.6
 
 RUN cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
@@ -17,14 +22,14 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 RUN mkdir /var/run/sshd
 
 RUN pip3 install --upgrade setuptools
-RUN pip3 install --upgrade pip==9.0.1
+RUN pip3 install --upgrade pip==10.0.1
 RUN pip3 install --upgrade virtualenv==15.1.0
 
 ADD . /src
 ENV PYTHONPATH=/src
 WORKDIR /src
 
-RUN pip3 install -r requirements.txt
+RUN python3 setup.py install
 RUN pip3 install -r requirements-dev.txt
 RUN pip3 install pymesos
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
-hypothesis
 # Testing dependencies
+docker-compose
+flake8
+hypothesis
 mock
 pre-commit
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-# Library so -e .
--e .
-boto3
-pyrsistent
-requests

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,12 @@ setup(
     packages=find_packages(exclude=('tests')),
     include_package_data=True,
     install_requires=[
-        'pyrsistent'
+        'pyrsistent',
     ],
     extras_require={
         # We can add the Mesos specific dependencies here
-        'mesos_executor': ['pymesos'],
+        'mesos_executor': ['addict', 'pymesos', 'requests'],
         'metrics': ['yelp-meteorite'],
+        'persistence': ['boto3'],
     }
 )

--- a/task_processing/interfaces/persistence.py
+++ b/task_processing/interfaces/persistence.py
@@ -1,10 +1,7 @@
 import abc
 
-import six
 
-
-@six.add_metaclass(abc.ABCMeta)
-class Persister():
+class Persister(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def read(self, task_id):

--- a/task_processing/interfaces/runner.py
+++ b/task_processing/interfaces/runner.py
@@ -1,12 +1,9 @@
 import abc
 
-import six
-
 from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Runner(object):
+class Runner(metaclass=abc.ABCMeta):
     TASK_CONFIG_INTERFACE = DefaultTaskConfigInterface
     """
     The interface, specified as a PRecord of

--- a/task_processing/interfaces/task_executor.py
+++ b/task_processing/interfaces/task_executor.py
@@ -1,7 +1,6 @@
 import abc
 import uuid
 
-import six
 from pyrsistent import field
 from pyrsistent import PRecord
 
@@ -11,8 +10,7 @@ class DefaultTaskConfigInterface(PRecord):
     name = field(type=str, initial='default')
 
 
-@six.add_metaclass(abc.ABCMeta)
-class TaskExecutor(object):
+class TaskExecutor(metaclass=abc.ABCMeta):
     """The core interface for Task Processing
     This is the class you want to implement to add a new TaskExecutor
     """

--- a/task_processing/metrics.py
+++ b/task_processing/metrics.py
@@ -5,7 +5,7 @@ except Exception:
     METRICS_ENABLED = False
 
 
-class _DummyMetricType(object):
+class _DummyMetricType:
     """
     Emulates a yelp_meteorite counter, gauge, or timer
     """

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -2,6 +2,7 @@ import logging
 import socket
 import threading
 import time
+from queue import Queue
 
 from addict import Dict
 from pymesos.interface import Scheduler
@@ -12,7 +13,6 @@ from pyrsistent import pmap
 from pyrsistent import PRecord
 from pyrsistent import thaw
 from pyrsistent import v
-from six.moves.queue import Queue
 
 from task_processing.interfaces.event import control_event
 from task_processing.interfaces.event import task_event

--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import time
+from queue import Queue
 from threading import Lock
 from threading import Thread
 from urllib.parse import urlparse
@@ -12,7 +13,6 @@ from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
 from pyrsistent import v
-from six.moves.queue import Queue
 
 from task_processing.interfaces.task_executor import TaskExecutor
 

--- a/task_processing/plugins/mesos/retrying_executor.py
+++ b/task_processing/plugins/mesos/retrying_executor.py
@@ -1,10 +1,10 @@
 import logging
 import time
+from queue import Queue
 from threading import Lock
 from threading import Thread
 
 from pyrsistent import m
-from six.moves.queue import Queue
 
 from task_processing.interfaces.task_executor import TaskExecutor
 

--- a/task_processing/plugins/mesos/timeout_executor.py
+++ b/task_processing/plugins/mesos/timeout_executor.py
@@ -1,10 +1,9 @@
 import collections
 import logging
 import time
+from queue import Queue
 from threading import Lock
 from threading import Thread
-
-from six.moves.queue import Queue
 
 from task_processing.interfaces.task_executor import TaskExecutor
 

--- a/task_processing/plugins/stateful/stateful_executor.py
+++ b/task_processing/plugins/stateful/stateful_executor.py
@@ -1,8 +1,7 @@
 import logging
 import threading
 import traceback
-
-from six.moves.queue import Queue
+from queue import Queue
 
 from task_processing.interfaces.task_executor import TaskExecutor
 

--- a/task_processing/runners/async.py
+++ b/task_processing/runners/async.py
@@ -2,9 +2,8 @@ import logging
 import os
 import traceback
 from collections import namedtuple
+from queue import Empty
 from threading import Thread
-
-from six.moves.queue import Empty
 
 from task_processing.interfaces.runner import Runner
 

--- a/task_processing/runners/subscription.py
+++ b/task_processing/runners/subscription.py
@@ -1,7 +1,6 @@
+from queue import Empty
+from queue import Full
 from threading import Thread
-
-from six.moves.queue import Empty
-from six.moves.queue import Full
 
 from task_processing.interfaces.runner import Runner
 

--- a/task_processing/runners/sync.py
+++ b/task_processing/runners/sync.py
@@ -1,7 +1,6 @@
 import logging
 import time
-
-from six.moves.queue import Queue
+from queue import Queue
 
 from task_processing.interfaces.runner import Runner
 

--- a/task_processing/task_processor.py
+++ b/task_processing/task_processor.py
@@ -41,7 +41,7 @@ class Registry(PRecord):
     """
 
 
-class TaskProcessor(object):
+class TaskProcessor:
     """Main Entry Point for Task Processing plugins
 
     This is the entrypoint to registering plugins (which know how to

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -1,13 +1,13 @@
 import socket
 import threading
 import time
+from queue import Queue
 
 import mock
 import pytest
 from addict import Dict
 from pyrsistent import m
 from pyrsistent import v
-from six.moves.queue import Queue
 
 from task_processing.plugins.mesos import execution_framework as ef_mdl
 from task_processing.plugins.mesos import mesos_executor as me_mdl

--- a/tests/unit/plugins/mesos/retrying_executor_test.py
+++ b/tests/unit/plugins/mesos/retrying_executor_test.py
@@ -1,8 +1,8 @@
 import threading
+from queue import Queue
 
 import mock
 import pytest
-from six.moves.queue import Queue
 
 from task_processing.interfaces.event import Event
 from task_processing.plugins.mesos.mesos_executor import MesosTaskConfig

--- a/tox.ini
+++ b/tox.ini
@@ -3,19 +3,16 @@ envlist = py36
 indexserver =
     default = https://pypi.python.org/simple
     private = https://pypi.yelpcorp.com/simple
-skipsdist=True
 
 [testenv]
 deps =
-    -rrequirements.txt
     -rrequirements-dev.txt
 commands =
-    pip install -e .[mesos_executor]
+    pip install -e .[mesos_executor,persistence]
     - pip install yelp-meteorite
-    pytest --cov=task_processing --cov-fail-under=30 -v {posargs:tests}/unit
+    pytest --cov=task_processing --cov-fail-under=75 -v {posargs:tests}/unit
     pre-commit install -f --install-hooks
     pre-commit run --all-files
-
 
 [testenv:mesos]
 basepython = /usr/bin/python3.6
@@ -46,3 +43,13 @@ commands =
   docker-compose -f examples/cluster/docker-compose.yaml scale mesosagent=1
   docker-compose -f examples/cluster/docker-compose.yaml \
     run playground /src/itest
+
+[testenv:venv]
+basepython = /usr/bin/python3.6
+envdir = venv
+commands =
+
+[flake8]
+exclude = .git,__pycache__,.tox,docs,venv
+filename = *.py
+max-line-length = 80 


### PR DESCRIPTION
This commit strips out six from taskproc -- there's nothing that's using taskproc on Python2.7 and Python2.7 is basically EOLed anyways, so let's not bother.

I also clean up the development environment/tox/etc a little bit here.