### PR TITLE
pull out offers and resources into another file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ ENV/
 *.sw[nop]
 
 .pytest_cache
+.mypy_cache

--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update -q && \
 
 RUN add-apt-repository ppa:jonathonf/python-3.6 
 RUN apt-get update -q && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.6
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.6 python3.6-dev python3.6-venv
+RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN python3.6 get-pip.py
+RUN ln -s /usr/bin/python3.6 /usr/local/bin/python3
 
 RUN cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports=True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ docker-compose
 flake8
 hypothesis
 mock
+mypy
 pre-commit
 pytest
 pytest-cov

--- a/task_processing/metrics.py
+++ b/task_processing/metrics.py
@@ -19,7 +19,7 @@ class _DummyMetricType:
 
 
 _dummy_metric = _DummyMetricType()
-_registered_metrics = {}
+_registered_metrics: dict = {}
 
 
 def create_counter(name, dimensions={}):

--- a/task_processing/plugins/mesos/resource_helpers.py
+++ b/task_processing/plugins/mesos/resource_helpers.py
@@ -1,0 +1,91 @@
+from typing import Tuple
+
+from pyrsistent import field
+from pyrsistent import pmap
+from pyrsistent import PRecord
+from pyrsistent import PVector
+from pyrsistent import pvector
+from pyrsistent import v
+
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
+
+NUMERIC_RESOURCE = field(
+    type=float,
+    initial=0.0,
+    factory=float,
+    invariant=lambda x: (x >= 0, 'resource < 0'),
+)
+_NUMERIC_RESOURCES = frozenset(['cpus', 'mem', 'disk', 'gpus'])
+
+
+class ResourceSet(PRecord):
+    cpus = NUMERIC_RESOURCE
+    mem = NUMERIC_RESOURCE
+    disk = NUMERIC_RESOURCE
+    gpus = NUMERIC_RESOURCE
+    ports = field(type=PVector, initial=v(), factory=pvector)
+
+
+def get_offer_resources(offer, role: str) -> ResourceSet:
+    """ Get the resources from a Mesos offer
+
+    :param offer: the payload from a Mesos resourceOffer call
+    :param role: the Mesos role we want to get resources for
+    :returns: a mapping from resource name -> available resources for the offer
+    """
+    res = ResourceSet()
+    for resource in offer.resources:
+        if resource.role != role:
+            continue
+
+        if resource.name in _NUMERIC_RESOURCES:
+            res = res.set(resource.name, resource.scalar.value)
+        elif resource.name == 'ports':
+            res = res.set('ports', [pmap(r) for r in resource.ranges.range])
+    return res
+
+
+def allocate_task_resources(
+    task: MesosTaskConfig,
+    offer_resources: ResourceSet,
+) -> Tuple[ResourceSet, ResourceSet]:
+    """ Allocate a task's resources to a Mesos offer
+
+    :param task: the specification for the task to allocate
+    :param offer_resources: a mapping of resource name -> available resources
+        (should come from :func:`get_offer_resources`)
+    :returns: a pair of (consumed_resources, remaining_resources)
+    """
+    consumed_resources = ResourceSet()
+    for res, val in offer_resources.items():
+        if res not in _NUMERIC_RESOURCES:
+            continue
+        consumed_resources = consumed_resources.set(res, task[res])
+        offer_resources = offer_resources.set(res, val - task[res])
+
+    port = offer_resources.ports[0].begin
+    if offer_resources.ports[0].begin == offer_resources.ports[0].end:
+        avail_ports = offer_resources.ports[1:]
+    else:
+        new_port_range = offer_resources.ports[0].set('begin', port + 1)
+        avail_ports = offer_resources.ports.set(0, new_port_range)
+    offer_resources = offer_resources.set('ports', avail_ports)
+    consumed_resources = consumed_resources.set('ports', v(port))
+    return consumed_resources, offer_resources
+
+
+def task_fits(task: MesosTaskConfig, offer_resources: ResourceSet) -> bool:
+    """ Check to see if a task fits a given offer's resources
+
+    :param task: the task specification to check
+    :param offer_resources: a mapping of resource name -> available resources
+        (should come from :func:`get_offer_resources`)
+    :returns: True if the offer has enough resources for the task, False otherwise
+    """
+    for rname, value in offer_resources.items():
+        if rname in _NUMERIC_RESOURCES and task[rname] > value:
+            return False
+        elif rname == 'ports' and len(value) == 0:  # TODO validate port ranges
+            return False
+
+    return True

--- a/tests/unit/plugins/mesos/conftest.py
+++ b/tests/unit/plugins/mesos/conftest.py
@@ -1,0 +1,74 @@
+import pytest
+from addict import Dict
+
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
+
+
+@pytest.fixture
+def fake_task():
+    return MesosTaskConfig(
+        name='fake_name',
+        cpus=10.0,
+        mem=1024.0,
+        disk=1000.0,
+        gpus=1,
+        image='fake_image',
+        cmd='echo "fake"'
+    )
+
+
+@pytest.fixture
+def fake_offer():
+    return Dict(
+        id=Dict(value='fake_offer_id'),
+        agent_id=Dict(value='fake_agent_id'),
+        hostname='fake_hostname',
+        resources=[
+            Dict(
+                role='fake_role',
+                name='cpus',
+                scalar=Dict(value=10),
+                type='SCALAR',
+            ),
+            Dict(
+                role='other_fake_role',
+                name='cpus',
+                scalar=Dict(value=20),
+                type='SCALAR',
+            ),
+            Dict(
+                role='fake_role',
+                name='mem',
+                scalar=Dict(value=1024),
+                type='SCALAR',
+            ),
+            Dict(
+                role='fake_role',
+                name='disk',
+                scalar=Dict(value=1000),
+                type='SCALAR',
+            ),
+            Dict(
+                role='fake_role',
+                name='gpus',
+                scalar=Dict(value=1),
+                type='SCALAR',
+            ),
+            Dict(
+                role='fake_role',
+                name='ports',
+                ranges=Dict(range=[Dict(begin=31200, end=31500)]),
+                type='RANGES',
+            ),
+        ],
+        attributes=[
+            Dict(
+                name='pool',
+                text=Dict(value='fake_pool_text')
+            ),
+            Dict(
+                name='region',
+                text=Dict(value='fake_region_text'),
+            ),
+        ]
+    )

--- a/tests/unit/plugins/mesos/resource_helpers_test.py
+++ b/tests/unit/plugins/mesos/resource_helpers_test.py
@@ -1,0 +1,67 @@
+import pytest
+from pyrsistent import m
+from pyrsistent import v
+
+from task_processing.plugins.mesos.resource_helpers import allocate_task_resources
+from task_processing.plugins.mesos.resource_helpers import get_offer_resources
+from task_processing.plugins.mesos.resource_helpers import ResourceSet
+from task_processing.plugins.mesos.resource_helpers import task_fits
+
+
+@pytest.fixture
+def offer_resources():
+    return ResourceSet(
+        cpus=10,
+        mem=1024,
+        disk=1000,
+        gpus=1,
+    )
+
+
+@pytest.mark.parametrize('role', ['fake_role', 'none'])
+def test_get_offer_resources(fake_offer, role):
+    assert get_offer_resources(fake_offer, role) == ResourceSet(
+        cpus=10 if role != 'none' else 0,
+        mem=1024 if role != 'none' else 0,
+        disk=1000 if role != 'none' else 0,
+        gpus=1 if role != 'none' else 0,
+        ports=v(m(begin=31200, end=31500)) if role != 'none' else v(),
+    )
+
+
+@pytest.mark.parametrize('available_ports', [
+    v(m(begin=5, end=10)),
+    v(m(begin=3, end=3), m(begin=6, end=10)),
+])
+def test_allocate_task_resources(fake_task, offer_resources, available_ports):
+    offer_resources = offer_resources.set('ports', available_ports)
+    expected_port = available_ports[0].begin
+    consumed, remaining = allocate_task_resources(fake_task, offer_resources)
+    assert consumed == {
+        'cpus': 10,
+        'mem': 1024,
+        'disk': 1000,
+        'gpus': 1,
+        'ports': v(expected_port),
+    }
+    assert remaining == {
+        'cpus': 0,
+        'mem': 0,
+        'disk': 0,
+        'gpus': 0,
+        'ports': v(m(begin=6, end=10)),
+    }
+
+
+@pytest.mark.parametrize('cpus,available_ports', [
+    (5, v([m(begin=5, end=10)])),
+    (10, v()),
+    (10, v([m(begin=5, end=10)])),
+])
+def test_task_fits(fake_task, offer_resources, cpus, available_ports):
+    offer_resources = offer_resources.set('cpus', cpus)
+    offer_resources = offer_resources.set('ports', available_ports)
+    assert task_fits(fake_task, offer_resources) == (
+        cpus == 10 and
+        len(available_ports) > 0
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
 commands =
     pip install -e .[mesos_executor,persistence]
     - pip install yelp-meteorite
+    mypy task_processing
     pytest --cov=task_processing --cov-fail-under=75 -v {posargs:tests}/unit
     pre-commit install -f --install-hooks
     pre-commit run --all-files
@@ -48,8 +49,9 @@ commands =
 basepython = /usr/bin/python3.6
 envdir = venv
 commands =
+    pip install -e .[mesos_executor,metrics,persistence]
 
 [flake8]
 exclude = .git,__pycache__,.tox,docs,venv
 filename = *.py
-max-line-length = 80 
+max-line-length = 100


### PR DESCRIPTION
This change does the following:

* _actually_ use python3.6 in the examples Docker container; in my last request I just installed it, but all the scripts were still using python3.5
* bumps max line length to 100; there are so many long imports and things that we have to go through some pretty painful shenanigans to fit into 80 characters
* pulls out and DRYs up code around handling resource offers: this makes it more extensible and will get re-used when I create the pod executor
* changes the logic around how ports are handled; instead of passing around range() objects for all the ports that are available, we just pass a (begin, end) pair, which we update every time a port gets used
* some initial mypy support
