### PR TITLE
[fix] Killing task during get_tasks_to_launch will cause exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,8 +90,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
-# Vim
+# Editors
 *.sw[nop]
+.vscode
 
 .pytest_cache
 .mypy_cache


### PR DESCRIPTION
`get_tasks_to_launch` removes task from the queue to prepare it for launch. if `kill_task` is called during that time - task metadata will be removed which will cause an exception.

let's wrap to chunk from `get_tasks_to_launch` and until we get a response from driver in a lock so nothing will interrupt and mess with the metadata in between.