### PR TITLE
handle offer response by the MesosTaskExecutor instead of the ExecutionFramework

### DIFF
--- a/examples/async.py
+++ b/examples/async.py
@@ -27,7 +27,7 @@ def main():
     processor = TaskProcessor()
     processor.load_plugin(provider_module='task_processing.plugins.mesos')
     executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': args.secret,
             'mesos_address': args.master,

--- a/examples/dynamo_persistence.py
+++ b/examples/dynamo_persistence.py
@@ -24,7 +24,7 @@ def main():
     for p in ['mesos', 'stateful']:
         processor.load_plugin(provider_module='task_processing.plugins.' + p)
     mesos_executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': secret,
             'mesos_address': mesos_address,

--- a/examples/file_persistence.py
+++ b/examples/file_persistence.py
@@ -21,7 +21,7 @@ def main():
     for p in ['mesos', 'stateful']:
         processor.load_plugin(provider_module='task_processing.plugins.' + p)
     mesos_executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': secret,
             'mesos_address': mesos_address,

--- a/examples/hello-world.py
+++ b/examples/hello-world.py
@@ -27,7 +27,7 @@ def main():
     # executor) using this defined configuration. this config can also be used
     # to specify other Mesos properties, such as which role to use
     executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': secret,
             'mesos_address': mesos_address,

--- a/examples/offer_timeout.py
+++ b/examples/offer_timeout.py
@@ -28,7 +28,7 @@ def main():
     processor = TaskProcessor()
     processor.load_plugin(provider_module='task_processing.plugins.mesos')
     mesos_executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': args.secret,
             'mesos_address': args.master,

--- a/examples/promise.py
+++ b/examples/promise.py
@@ -18,7 +18,7 @@ def main():
     processor = TaskProcessor()
     processor.load_plugin(provider_module='task_processing.plugins.mesos')
     executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': args.secret,
             'mesos_address': args.master,

--- a/examples/retry.py
+++ b/examples/retry.py
@@ -16,7 +16,7 @@ def main():
     processor = TaskProcessor()
     processor.load_plugin(provider_module='task_processing.plugins.mesos')
     mesos_executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': args.secret,
             'mesos_address': args.master,

--- a/examples/subscription.py
+++ b/examples/subscription.py
@@ -21,7 +21,7 @@ def main():
     processor = TaskProcessor()
     processor.load_plugin(provider_module='task_processing.plugins.mesos')
     executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': secret,
             'mesos_address': mesos_address,

--- a/examples/sync.py
+++ b/examples/sync.py
@@ -16,7 +16,7 @@ def main():
     processor = TaskProcessor()
     processor.load_plugin(provider_module='task_processing.plugins.mesos')
     executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': args.secret,
             'mesos_address': args.master,

--- a/examples/task_logging.py
+++ b/examples/task_logging.py
@@ -16,7 +16,7 @@ def main():
     processor = TaskProcessor()
     processor.load_plugin(provider_module='task_processing.plugins.mesos')
     mesos_executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': args.secret,
             'mesos_address': args.master,

--- a/examples/timeout.py
+++ b/examples/timeout.py
@@ -16,7 +16,7 @@ def main():
     processor = TaskProcessor()
     processor.load_plugin(provider_module='task_processing.plugins.mesos')
     mesos_executor = processor.executor_from_config(
-        provider='mesos',
+        provider='mesos_task',
         provider_config={
             'secret': args.secret,
             'mesos_address': args.master,

--- a/task_processing/plugins/mesos/__init__.py
+++ b/task_processing/plugins/mesos/__init__.py
@@ -1,5 +1,6 @@
 from .logging_executor import MesosLoggingExecutor
-from .mesos_executor import MesosExecutor
+from .mesos_pod_executor import MesosPodExecutor
+from .mesos_task_executor import MesosTaskExecutor
 from .retrying_executor import RetryingExecutor
 from .timeout_executor import TimeoutExecutor
 
@@ -10,6 +11,7 @@ TASK_PROCESSING_PLUGIN = 'mesos_plugin'
 def register_plugin(registry):
     return registry \
         .register_task_executor('logging', MesosLoggingExecutor) \
-        .register_task_executor('mesos', MesosExecutor) \
+        .register_task_executor('mesos_task', MesosTaskExecutor) \
+        .register_task_executor('mesos_pod', MesosPodExecutor) \
         .register_task_executor('retrying', RetryingExecutor) \
         .register_task_executor('timeout', TimeoutExecutor)

--- a/task_processing/plugins/mesos/__init__.py
+++ b/task_processing/plugins/mesos/__init__.py
@@ -11,6 +11,7 @@ TASK_PROCESSING_PLUGIN = 'mesos_plugin'
 def register_plugin(registry):
     return registry \
         .register_task_executor('logging', MesosLoggingExecutor) \
+        .register_deprecated_task_executor('mesos', MesosTaskExecutor) \
         .register_task_executor('mesos_task', MesosTaskExecutor) \
         .register_task_executor('mesos_pod', MesosPodExecutor) \
         .register_task_executor('retrying', RetryingExecutor) \

--- a/task_processing/plugins/mesos/constraints.py
+++ b/task_processing/plugins/mesos/constraints.py
@@ -63,9 +63,3 @@ class Constraint(PRecord):
     attribute = field(type=str)
     operator = field(type=str, invariant=valid_constraint_operator_name)
     value = field(type=str)
-
-
-def offer_matches_task_constraints(offer, task):
-    attributes = {attribute.name: attribute.text.value for attribute in
-                  offer.attributes}
-    return attributes_match_constraints(attributes, task.constraints)

--- a/task_processing/plugins/mesos/mesos_executor.py
+++ b/task_processing/plugins/mesos/mesos_executor.py
@@ -1,31 +1,43 @@
-import abc
 import logging
 import threading
+from typing import Callable
+from typing import List
+from typing import NamedTuple
+from typing import Tuple
 
+import addict
 from pymesos import MesosSchedulerDriver
 
+from task_processing.interfaces.event import Event
 from task_processing.interfaces.task_executor import TaskExecutor
 from task_processing.plugins.mesos.execution_framework import ExecutionFramework
+from task_processing.plugins.mesos.resource_helpers import ResourceSet
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
 
 FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
 logging.basicConfig(format=FORMAT)
 
 
-class MesosExecutorCallbackInterface(metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    def get_tasks_for_offer(self, task_configs, offer):
-        pass
+class MesosExecutorCallbacks(NamedTuple):
+    get_tasks_for_offer: Callable[
+        [List[MesosTaskConfig], ResourceSet, dict, str],
+        Tuple[List[addict.Dict], List[MesosTaskConfig]]
+    ]
+    handle_status_update: Callable[
+        [addict.Dict, MesosTaskConfig],
+        Event,
+    ]
+    make_mesos_protobuf: Callable[
+        [MesosTaskConfig, str, str],
+        addict.Dict,
+    ]
 
-    @abc.abstractmethod
-    def process_status_update(self, update, task_config):
-        pass
 
-
-class AbstractMesosExecutor(TaskExecutor, MesosExecutorCallbackInterface):
-
+class MesosExecutor(TaskExecutor):
     def __init__(
         self,
-        role,
+        role: str,
+        callbacks: MesosExecutorCallbacks,
         pool=None,
         principal='taskproc',
         secret=None,
@@ -33,7 +45,7 @@ class AbstractMesosExecutor(TaskExecutor, MesosExecutorCallbackInterface):
         initial_decline_delay=1.0,
         framework_name='taskproc-default',
         framework_staging_timeout=240,
-    ):
+    ) -> None:
         """
         Constructs the instance of a task execution, encapsulating all state
         required to run, monitor and stop the job.
@@ -48,7 +60,7 @@ class AbstractMesosExecutor(TaskExecutor, MesosExecutorCallbackInterface):
             role=role,
             pool=pool,
             name=framework_name,
-            callback_interface=self,
+            callbacks=callbacks,
             task_staging_timeout_s=framework_staging_timeout,
             initial_decline_delay=initial_decline_delay
         )

--- a/task_processing/plugins/mesos/mesos_pod_executor.py
+++ b/task_processing/plugins/mesos/mesos_pod_executor.py
@@ -1,26 +1,6 @@
-import logging
-from typing import Any
-from typing import List
-from typing import Tuple
-
-import addict
-
-from task_processing.plugins.mesos.mesos_executor import AbstractMesosExecutor
-from task_processing.plugins.mesos.task_config import MesosTaskConfig
-
-FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
-logging.basicConfig(format=FORMAT)
-log = logging.getLogger(__name__)
+from task_processing.plugins.mesos.mesos_executor import MesosExecutor
 
 
-class MesosPodExecutor(AbstractMesosExecutor):
-
-    def get_tasks_for_offer(
-        self,
-        task_configs: List[MesosTaskConfig],
-        offer: addict.Dict,
-    ) -> Tuple[List[Any], List[MesosTaskConfig]]:
-        raise NotImplementedError
-
-    def process_status_update(self):
+class MesosPodExecutor(MesosExecutor):
+    def __init__(self, role, *args, **kwargs) -> None:
         raise NotImplementedError

--- a/task_processing/plugins/mesos/mesos_pod_executor.py
+++ b/task_processing/plugins/mesos/mesos_pod_executor.py
@@ -15,9 +15,12 @@ log = logging.getLogger(__name__)
 
 class MesosPodExecutor(AbstractMesosExecutor):
 
-    def handle_offer(
+    def get_tasks_for_offer(
         self,
         task_configs: List[MesosTaskConfig],
         offer: addict.Dict,
     ) -> Tuple[List[Any], List[MesosTaskConfig]]:
+        raise NotImplementedError
+
+    def process_status_update(self):
         raise NotImplementedError

--- a/task_processing/plugins/mesos/mesos_pod_executor.py
+++ b/task_processing/plugins/mesos/mesos_pod_executor.py
@@ -1,0 +1,23 @@
+import logging
+from typing import Any
+from typing import List
+from typing import Tuple
+
+import addict
+
+from task_processing.plugins.mesos.mesos_executor import AbstractMesosExecutor
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
+
+FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
+logging.basicConfig(format=FORMAT)
+log = logging.getLogger(__name__)
+
+
+class MesosPodExecutor(AbstractMesosExecutor):
+
+    def handle_offer(
+        self,
+        task_configs: List[MesosTaskConfig],
+        offer: addict.Dict,
+    ) -> Tuple[List[Any], List[MesosTaskConfig]]:
+        raise NotImplementedError

--- a/task_processing/plugins/mesos/mesos_task_executor.py
+++ b/task_processing/plugins/mesos/mesos_task_executor.py
@@ -1,0 +1,49 @@
+import logging
+from typing import List
+from typing import Tuple
+
+import addict
+
+from task_processing.plugins.mesos.constraints import offer_matches_task_constraints
+from task_processing.plugins.mesos.mesos_executor import AbstractMesosExecutor
+from task_processing.plugins.mesos.resource_helpers import allocate_task_resources
+from task_processing.plugins.mesos.resource_helpers import get_offer_resources
+from task_processing.plugins.mesos.resource_helpers import task_fits
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
+from task_processing.plugins.mesos.translator import make_mesos_task_info
+
+FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
+logging.basicConfig(format=FORMAT)
+log = logging.getLogger(__name__)
+
+
+class MesosTaskExecutor(AbstractMesosExecutor):
+    TASK_CONFIG_INTERFACE = MesosTaskConfig
+
+    def handle_offer(
+        self,
+        task_configs: List[MesosTaskConfig],
+        offer: addict.Dict,
+    ) -> Tuple[List[addict.Dict], List[MesosTaskConfig]]:
+        offer_resources = get_offer_resources(offer, self.role)
+        log.info(f'Received offer {offer.id.value} for role {self.role}: {offer_resources}')
+        tasks_to_launch, tasks_to_defer = [], []
+
+        for task_config in task_configs:
+            if (task_fits(task_config, offer_resources) and
+                    offer_matches_task_constraints(offer, task_config)):
+                consumed_resources, offer_resources = allocate_task_resources(
+                    task_config,
+                    offer_resources,
+                )
+                mesos_task_info = make_mesos_task_info(
+                    task_config,
+                    consumed_resources,
+                    offer,
+                    self.role,
+                )
+                tasks_to_launch.append(mesos_task_info)
+            else:
+                tasks_to_defer.append(task_config)
+
+        return tasks_to_launch, tasks_to_defer

--- a/task_processing/plugins/mesos/mesos_task_executor.py
+++ b/task_processing/plugins/mesos/mesos_task_executor.py
@@ -1,54 +1,48 @@
-import logging
 from typing import List
 from typing import Tuple
 
-import addict
-
-from task_processing.interfaces.event import Event
-from task_processing.plugins.mesos.constraints import offer_matches_task_constraints
-from task_processing.plugins.mesos.mesos_executor import AbstractMesosExecutor
+from task_processing.plugins.mesos.constraints import attributes_match_constraints
+from task_processing.plugins.mesos.mesos_executor import MesosExecutor
+from task_processing.plugins.mesos.mesos_executor import MesosExecutorCallbacks
 from task_processing.plugins.mesos.resource_helpers import allocate_task_resources
-from task_processing.plugins.mesos.resource_helpers import get_offer_resources
+from task_processing.plugins.mesos.resource_helpers import ResourceSet
 from task_processing.plugins.mesos.resource_helpers import task_fits
 from task_processing.plugins.mesos.task_config import MesosTaskConfig
 from task_processing.plugins.mesos.translator import make_mesos_task_info
 from task_processing.plugins.mesos.translator import mesos_update_to_event
 
-FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
-logging.basicConfig(format=FORMAT)
-log = logging.getLogger(__name__)
+
+def get_tasks_for_offer(
+    task_configs: List[MesosTaskConfig],
+    offer_resources: ResourceSet,
+    offer_attributes: dict,
+    role: str,
+) -> Tuple[List[MesosTaskConfig], List[MesosTaskConfig]]:
+
+    tasks_to_launch, tasks_to_defer = [], []
+
+    for task_config in task_configs:
+        if (task_fits(task_config, offer_resources) and
+                attributes_match_constraints(offer_attributes, task_config.constraints)):
+            task_config, offer_resources = allocate_task_resources(task_config, offer_resources)
+            tasks_to_launch.append(task_config)
+        else:
+            tasks_to_defer.append(task_config)
+
+    return tasks_to_launch, tasks_to_defer
 
 
-class MesosTaskExecutor(AbstractMesosExecutor):
+class MesosTaskExecutor(MesosExecutor):
     TASK_CONFIG_INTERFACE = MesosTaskConfig
 
-    def get_tasks_for_offer(
-        self,
-        task_configs: List[MesosTaskConfig],
-        offer: addict.Dict,
-    ) -> Tuple[List[addict.Dict], List[MesosTaskConfig]]:
-        offer_resources = get_offer_resources(offer, self.role)
-        log.info(f'Received offer {offer.id.value} for role {self.role}: {offer_resources}')
-        tasks_to_launch, tasks_to_defer = [], []
-
-        for task_config in task_configs:
-            if (task_fits(task_config, offer_resources) and
-                    offer_matches_task_constraints(offer, task_config)):
-                consumed_resources, offer_resources = allocate_task_resources(
-                    task_config,
-                    offer_resources,
-                )
-                mesos_task_info = make_mesos_task_info(
-                    task_config,
-                    consumed_resources,
-                    offer,
-                    self.role,
-                )
-                tasks_to_launch.append(mesos_task_info)
-            else:
-                tasks_to_defer.append(task_config)
-
-        return tasks_to_launch, tasks_to_defer
-
-    def process_status_update(self, update: addict.Dict, task_config: MesosTaskConfig) -> Event:
-        return mesos_update_to_event(update, task_config)
+    def __init__(self, role, *args, **kwargs) -> None:
+        super().__init__(
+            role,
+            MesosExecutorCallbacks(
+                get_tasks_for_offer,
+                mesos_update_to_event,
+                make_mesos_task_info,
+            ),
+            *args,
+            **kwargs,
+        )

--- a/task_processing/plugins/mesos/mesos_task_executor.py
+++ b/task_processing/plugins/mesos/mesos_task_executor.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 import addict
 
+from task_processing.interfaces.event import Event
 from task_processing.plugins.mesos.constraints import offer_matches_task_constraints
 from task_processing.plugins.mesos.mesos_executor import AbstractMesosExecutor
 from task_processing.plugins.mesos.resource_helpers import allocate_task_resources
@@ -11,6 +12,7 @@ from task_processing.plugins.mesos.resource_helpers import get_offer_resources
 from task_processing.plugins.mesos.resource_helpers import task_fits
 from task_processing.plugins.mesos.task_config import MesosTaskConfig
 from task_processing.plugins.mesos.translator import make_mesos_task_info
+from task_processing.plugins.mesos.translator import mesos_update_to_event
 
 FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s - %(message)s'
 logging.basicConfig(format=FORMAT)
@@ -20,7 +22,7 @@ log = logging.getLogger(__name__)
 class MesosTaskExecutor(AbstractMesosExecutor):
     TASK_CONFIG_INTERFACE = MesosTaskConfig
 
-    def handle_offer(
+    def get_tasks_for_offer(
         self,
         task_configs: List[MesosTaskConfig],
         offer: addict.Dict,
@@ -47,3 +49,6 @@ class MesosTaskExecutor(AbstractMesosExecutor):
                 tasks_to_defer.append(task_config)
 
         return tasks_to_launch, tasks_to_defer
+
+    def process_status_update(self, update: addict.Dict, task_config: MesosTaskConfig) -> Event:
+        return mesos_update_to_event(update, task_config)

--- a/task_processing/plugins/mesos/metrics.py
+++ b/task_processing/plugins/mesos/metrics.py
@@ -1,0 +1,18 @@
+TASK_LAUNCHED_COUNT = 'taskproc.mesos.task_launched_count'
+TASK_FAILED_TO_LAUNCH_COUNT = 'taskproc.mesos.tasks_failed_to_launch_count'
+TASK_LAUNCH_FAILED_COUNT = 'taskproc.mesos.task_launch_failed_count'
+TASK_FINISHED_COUNT = 'taskproc.mesos.task_finished_count'
+TASK_FAILED_COUNT = 'taskproc.mesos.task_failure_count'
+TASK_KILLED_COUNT = 'taskproc.mesos.task_killed_count'
+TASK_LOST_COUNT = 'taskproc.mesos.task_lost_count'
+TASK_LOST_DUE_TO_INVALID_OFFER_COUNT = 'taskproc.mesos.task_lost_due_to_invalid_offer_count'
+TASK_ERROR_COUNT = 'taskproc.mesos.task_error_count'
+TASK_OFFER_TIMEOUT = 'taskproc.mesos.task_offer_timeout'
+
+TASK_ENQUEUED_COUNT = 'taskproc.mesos.task_enqueued_count'
+TASK_QUEUED_TIME_TIMER = 'taskproc.mesos.task_queued_time'
+TASK_INSUFFICIENT_OFFER_COUNT = 'taskproc.mesos.task_insufficient_offer_count'
+TASK_STUCK_COUNT = 'taskproc.mesos.task_stuck_count'
+
+OFFER_DELAY_TIMER = 'taskproc.mesos.offer_delay'
+BLACKLISTED_AGENTS_COUNT = 'taskproc.mesos.blacklisted_agents_count'

--- a/task_processing/plugins/mesos/resource_helpers.py
+++ b/task_processing/plugins/mesos/resource_helpers.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+import addict
 from pyrsistent import field
 from pyrsistent import pmap
 from pyrsistent import PRecord
@@ -26,7 +27,7 @@ class ResourceSet(PRecord):
     ports = field(type=PVector, initial=v(), factory=pvector)
 
 
-def get_offer_resources(offer, role: str) -> ResourceSet:
+def get_offer_resources(offer: addict.Dict, role: str) -> ResourceSet:
     """ Get the resources from a Mesos offer
 
     :param offer: the payload from a Mesos resourceOffer call

--- a/task_processing/plugins/mesos/resource_helpers.py
+++ b/task_processing/plugins/mesos/resource_helpers.py
@@ -2,6 +2,7 @@ from typing import Tuple
 
 import addict
 from pyrsistent import field
+from pyrsistent import m
 from pyrsistent import pmap
 from pyrsistent import PRecord
 from pyrsistent import PVector
@@ -47,9 +48,9 @@ def get_offer_resources(offer: addict.Dict, role: str) -> ResourceSet:
 
 
 def allocate_task_resources(
-    task: MesosTaskConfig,
+    task_config: MesosTaskConfig,
     offer_resources: ResourceSet,
-) -> Tuple[ResourceSet, ResourceSet]:
+) -> Tuple[MesosTaskConfig, ResourceSet]:
     """ Allocate a task's resources to a Mesos offer
 
     :param task: the specification for the task to allocate
@@ -57,12 +58,10 @@ def allocate_task_resources(
         (should come from :func:`get_offer_resources`)
     :returns: a pair of (consumed_resources, remaining_resources)
     """
-    consumed_resources = ResourceSet()
     for res, val in offer_resources.items():
         if res not in _NUMERIC_RESOURCES:
             continue
-        consumed_resources = consumed_resources.set(res, task[res])
-        offer_resources = offer_resources.set(res, val - task[res])
+        offer_resources = offer_resources.set(res, val - task_config[res])
 
     port = offer_resources.ports[0].begin
     if offer_resources.ports[0].begin == offer_resources.ports[0].end:
@@ -71,8 +70,8 @@ def allocate_task_resources(
         new_port_range = offer_resources.ports[0].set('begin', port + 1)
         avail_ports = offer_resources.ports.set(0, new_port_range)
     offer_resources = offer_resources.set('ports', avail_ports)
-    consumed_resources = consumed_resources.set('ports', v(port))
-    return consumed_resources, offer_resources
+    task_config = task_config.set('ports', v(m(begin=port, end=port)))
+    return task_config, offer_resources
 
 
 def task_fits(task: MesosTaskConfig, offer_resources: ResourceSet) -> bool:

--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -117,6 +117,7 @@ class MesosTaskConfig(PRecord):
                                               value=v[2]) for v in c)),
         invariant=_valid_constraints,
     )
+    use_cached_image = field(type=bool, initial=True, factory=bool)
 
     @property
     def task_id(self):

--- a/task_processing/plugins/mesos/translator.py
+++ b/task_processing/plugins/mesos/translator.py
@@ -1,8 +1,113 @@
 import time
+from typing import List
+
+import addict
+from pyrsistent import thaw
 
 from task_processing.interfaces.event import task_event
+from task_processing.plugins.mesos.resource_helpers import ResourceSet
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
 
 # https://github.com/apache/mesos/blob/master/include/mesos/mesos.proto
+
+
+def make_mesos_container_info(task_config: MesosTaskConfig, port: int) -> addict.Dict:
+    container_info = addict.Dict(
+        type=task_config.containerizer,
+        volumes=thaw(task_config.volumes),
+    )
+    port_mappings = [addict.Dict(host_port=port, container_port=8888)]
+    if container_info.type == 'DOCKER':
+        container_info.docker = addict.Dict(
+            image=task_config.image,
+            network='BRIDGE',
+            port_mappings=port_mappings,
+            parameters=thaw(task_config.docker_parameters),
+            force_pull_image=(not task_config.use_cached_image),
+        )
+    elif container_info.type == 'MESOS':
+        container_info.network_infos = addict.Dict(port_mappings=port_mappings)
+        # For this to work, image_providers needs to be set to 'docker' on mesos agents (as opposed
+        # to 'appc' or 'oci'; we're still running docker images, we're just using the UCR to do it).
+        if 'image' in task_config:
+            container_info.mesos.image = addict.Dict(
+                type='DOCKER',  # not 'APPC' or 'OCI'
+                docker=addict.Dict(name=task_config.image),
+                cached=task_config.use_cached_image,
+            )
+    return container_info
+
+
+def make_mesos_resources(
+    consumed_resources: ResourceSet,
+    port: int,
+    role: str,
+) -> List[addict.Dict]:
+    return [
+        addict.Dict(
+            name='cpus',
+            type='SCALAR',
+            role=role,
+            scalar=addict.Dict(value=consumed_resources.cpus),
+        ),
+        addict.Dict(
+            name='mem',
+            type='SCALAR',
+            role=role,
+            scalar=addict.Dict(value=consumed_resources.mem)
+        ),
+        addict.Dict(
+            name='disk',
+            type='SCALAR',
+            role=role,
+            scalar=addict.Dict(value=consumed_resources.disk)
+        ),
+        addict.Dict(
+            name='gpus',
+            type='SCALAR',
+            role=role,
+            scalar=addict.Dict(value=consumed_resources.gpus)
+        ),
+        addict.Dict(
+            name='ports',
+            type='RANGES',
+            role=role,
+            ranges=addict.Dict(range=[addict.Dict(begin=port, end=port)])
+        ),
+    ]
+
+
+def make_mesos_command_info(task_config: MesosTaskConfig) -> addict.Dict:
+    return addict.Dict(
+        value=task_config.cmd,
+        uris=[addict.Dict(value=uri, extract=False) for uri in task_config.uris],
+        environment=addict.Dict(
+            variables=[addict.Dict(name=k, value=v) for k, v in task_config.environment.items()],
+        )
+    )
+
+
+def make_mesos_task_info(
+    task_config: MesosTaskConfig,
+    consumed_resources: ResourceSet,
+    offer: addict.Dict,
+    role: str,
+) -> addict.Dict:
+
+    port = consumed_resources['ports'][0]
+    container_info = make_mesos_container_info(task_config, port)
+    resources = make_mesos_resources(consumed_resources, port, role)
+    command_info = make_mesos_command_info(task_config)
+
+    return addict.Dict(
+        task_id=addict.Dict(value=task_config.task_id),
+        agent_id=addict.Dict(value=offer.agent_id.value),
+        name=f'executor-{task_config.task_id}',
+        resources=resources,
+        command=command_info,
+        container=container_info
+    )
+
 
 MESOS_STATUS_MAP = {
     'TASK_STARTING':

--- a/task_processing/plugins/mesos/translator.py
+++ b/task_processing/plugins/mesos/translator.py
@@ -4,6 +4,7 @@ from typing import List
 import addict
 from pyrsistent import thaw
 
+from task_processing.interfaces.event import Event
 from task_processing.interfaces.event import task_event
 from task_processing.plugins.mesos.resource_helpers import ResourceSet
 from task_processing.plugins.mesos.task_config import MesosTaskConfig
@@ -111,42 +112,42 @@ def make_mesos_task_info(
 
 MESOS_STATUS_MAP = {
     'TASK_STARTING':
-    dict(platform_type='starting', terminal=False),
+    addict.Dict(platform_type='starting', terminal=False),
     'TASK_RUNNING':
-    dict(platform_type='running', terminal=False),
+    addict.Dict(platform_type='running', terminal=False),
     'TASK_FINISHED':
-    dict(platform_type='finished', terminal=True, success=True),
+    addict.Dict(platform_type='finished', terminal=True, success=True),
     'TASK_FAILED':
-    dict(platform_type='failed', terminal=True, success=False),
+    addict.Dict(platform_type='failed', terminal=True, success=False),
     'TASK_KILLED':
-    dict(platform_type='killed', terminal=True, success=False),
+    addict.Dict(platform_type='killed', terminal=True, success=False),
     'TASK_LOST':
-    dict(platform_type='lost', terminal=True, success=False),
+    addict.Dict(platform_type='lost', terminal=True, success=False),
     'TASK_STAGING':
-    dict(platform_type='staging', terminal=False),
+    addict.Dict(platform_type='staging', terminal=False),
     'TASK_ERROR':
-    dict(platform_type='error', terminal=True, success=False),
+    addict.Dict(platform_type='error', terminal=True, success=False),
     'TASK_KILLING':
-    dict(platform_type='killing', terminal=False),
+    addict.Dict(platform_type='killing', terminal=False),
     'TASK_DROPPED':
-    dict(platform_type='dropped', terminal=True, success=False),
+    addict.Dict(platform_type='dropped', terminal=True, success=False),
     'TASK_UNREACHABLE':
-    dict(platform_type='unreachable', terminal=False),
+    addict.Dict(platform_type='unreachable', terminal=False),
     'TASK_GONE':
-    dict(platform_type='gone', terminal=True, success=False),
+    addict.Dict(platform_type='gone', terminal=True, success=False),
     'TASK_GONE_BY_OPERATOR':
-    dict(platform_type='gone_by_operator', terminal=True, success=False),
+    addict.Dict(platform_type='gone_by_operator', terminal=True, success=False),
     'TASK_UNKNOWN':
-    dict(platform_type='unknown', terminal=False)
+    addict.Dict(platform_type='unknown', terminal=False)
 }
 
 
-def mesos_status_to_event(mesos_status, task_id, **kwargs):
-    kwargs2 = dict(
+def mesos_update_to_event(mesos_status: addict.Dict, task_config: MesosTaskConfig) -> Event:
+    kwargs = dict(
         raw=mesos_status,
-        task_id=str(task_id),
+        task_id=task_config.task_id,
+        task_config=task_config,
         timestamp=time.time(),
     )
-    kwargs2.update(MESOS_STATUS_MAP[mesos_status.state])
-    kwargs2.update(kwargs)
-    return task_event(**kwargs2)
+    kwargs.update(MESOS_STATUS_MAP[mesos_status.state])
+    return task_event(**kwargs)

--- a/tests/unit/plugins/mesos/conftest.py
+++ b/tests/unit/plugins/mesos/conftest.py
@@ -1,8 +1,10 @@
 import threading
 
+import addict
 import mock
 import pytest
-from addict import Dict
+from pyrsistent import m
+from pyrsistent import v
 
 from task_processing.plugins.mesos.task_config import MesosTaskConfig
 
@@ -15,6 +17,7 @@ def fake_task():
         mem=1024.0,
         disk=1000.0,
         gpus=1,
+        ports=v(m(begin=31200, end=31200)),
         image='fake_image',
         cmd='echo "fake"'
     )
@@ -22,56 +25,56 @@ def fake_task():
 
 @pytest.fixture
 def fake_offer():
-    return Dict(
-        id=Dict(value='fake_offer_id'),
-        agent_id=Dict(value='fake_agent_id'),
+    return addict.Dict(
+        id=addict.Dict(value='fake_offer_id'),
+        agent_id=addict.Dict(value='fake_agent_id'),
         hostname='fake_hostname',
         resources=[
-            Dict(
+            addict.Dict(
                 role='fake_role',
                 name='cpus',
-                scalar=Dict(value=10),
+                scalar=addict.Dict(value=10),
                 type='SCALAR',
             ),
-            Dict(
+            addict.Dict(
                 role='other_fake_role',
                 name='cpus',
-                scalar=Dict(value=20),
+                scalar=addict.Dict(value=20),
                 type='SCALAR',
             ),
-            Dict(
+            addict.Dict(
                 role='fake_role',
                 name='mem',
-                scalar=Dict(value=1024),
+                scalar=addict.Dict(value=1024),
                 type='SCALAR',
             ),
-            Dict(
+            addict.Dict(
                 role='fake_role',
                 name='disk',
-                scalar=Dict(value=1000),
+                scalar=addict.Dict(value=1000),
                 type='SCALAR',
             ),
-            Dict(
+            addict.Dict(
                 role='fake_role',
                 name='gpus',
-                scalar=Dict(value=1),
+                scalar=addict.Dict(value=1),
                 type='SCALAR',
             ),
-            Dict(
+            addict.Dict(
                 role='fake_role',
                 name='ports',
-                ranges=Dict(range=[Dict(begin=31200, end=31500)]),
+                ranges=addict.Dict(range=[addict.Dict(begin=31200, end=31500)]),
                 type='RANGES',
             ),
         ],
         attributes=[
-            Dict(
+            addict.Dict(
                 name='pool',
-                text=Dict(value='fake_pool_text')
+                text=addict.Dict(value='fake_pool_text')
             ),
-            Dict(
+            addict.Dict(
                 name='region',
-                text=Dict(value='fake_region_text'),
+                text=addict.Dict(value='fake_region_text'),
             ),
         ]
     )

--- a/tests/unit/plugins/mesos/conftest.py
+++ b/tests/unit/plugins/mesos/conftest.py
@@ -1,3 +1,6 @@
+import threading
+
+import mock
 import pytest
 from addict import Dict
 
@@ -72,3 +75,20 @@ def fake_offer():
             ),
         ]
     )
+
+
+@pytest.fixture
+def mock_Thread():
+    with mock.patch.object(threading, 'Thread') as mock_Thread:
+        yield mock_Thread
+
+
+@pytest.fixture
+def mock_fw_and_driver():
+    with mock.patch(
+        'task_processing.plugins.mesos.mesos_executor.ExecutionFramework'
+    ) as mock_execution_framework, mock.patch(
+        'task_processing.plugins.mesos.mesos_executor.MesosSchedulerDriver'
+    ) as mock_scheduler_driver:
+        mock_execution_framework.return_value.framework_info = mock.Mock()
+        yield mock_execution_framework, mock_scheduler_driver

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -332,7 +332,7 @@ def test_resource_offers_launch(
         task_state_history=m(fake_state=time.time(), TASK_INITED=time.time())
     )
     fake_task_2 = mock.Mock()
-    ef.handle_offer = mock.Mock(return_value=([docker_task], [fake_task_2]))
+    ef.cb_interface.get_tasks_for_offer = mock.Mock(return_value=([docker_task], [fake_task_2]))
 
     ef.task_queue.put(fake_task)
     ef.task_queue.put(fake_task_2)
@@ -374,7 +374,7 @@ def test_resource_offers_launch_tasks_failed(
         task_state='fake_state',
         task_state_history=m(fake_state=time.time(), TASK_INITED=time.time())
     )
-    ef.handle_offer = mock.Mock(return_value=([docker_task], []))
+    ef.cb_interface.get_tasks_for_offer = mock.Mock(return_value=([docker_task], []))
     ef.task_queue.put(fake_task)
     ef.task_metadata = ef.task_metadata.set(task_id, task_metadata)
     ef.resourceOffers(ef.driver, [fake_offer])
@@ -462,7 +462,7 @@ def test_resource_offers_unmet_reqs(
     mock_driver,
     mock_get_metric
 ):
-    ef.handle_offer = mock.Mock(return_value=([], [fake_task]))
+    ef.cb_interface.get_tasks_for_offer = mock.Mock(return_value=([], [fake_task]))
 
     ef.task_queue.put(fake_task)
     ef.resourceOffers(mock_driver, [fake_offer])

--- a/tests/unit/plugins/mesos/mesos_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_executor_test.py
@@ -1,52 +1,43 @@
-import threading
-
 import mock
 import pytest
 
-import task_processing.plugins.mesos.mesos_executor as me_module
+from task_processing.plugins.mesos.mesos_executor import AbstractMesosExecutor
 from task_processing.plugins.mesos.translator import mesos_status_to_event
 
 
-@pytest.fixture
-def mock_Thread():
-    with mock.patch.object(threading, 'Thread') as mock_Thread:
-        yield mock_Thread
+class DummyMesosExecutor(AbstractMesosExecutor):
+    def handle_offer(task_configs, offer):
+        pass
 
 
 @pytest.fixture
-def mesos_executor(mocker, request, mock_Thread):
-    mocker.patch.object(me_module, 'ExecutionFramework')
-    mocker.patch.object(me_module, 'MesosSchedulerDriver')
-
-    ef = me_module.ExecutionFramework.return_value
-    fi = mocker.Mock()
-    ef.framework_info = fi
-    me = me_module.MesosExecutor("role")
+def mesos_executor(request, mock_Thread, mock_fw_and_driver):
+    dummy_executor = DummyMesosExecutor('role')
 
     def mesos_executor_teardown():
-        me.stop()
+        dummy_executor.stop()
     request.addfinalizer(mesos_executor_teardown)
 
-    return me
+    return dummy_executor
 
 
-def test_creates_execution_framework_and_driver(mock_Thread, mesos_executor):
-    ef = me_module.ExecutionFramework.return_value
-    assert mesos_executor.execution_framework is ef
-    assert me_module.ExecutionFramework.call_args == mock.call(
+def test_creates_execution_framework_and_driver(mock_Thread, mesos_executor, mock_fw_and_driver):
+    execution_framework, mesos_driver = mock_fw_and_driver
+    assert mesos_executor.execution_framework is execution_framework.return_value
+    assert execution_framework.call_args == mock.call(
         name="taskproc-default",
         task_staging_timeout_s=240,
         initial_decline_delay=1.0,
         translator=mesos_status_to_event,
         pool=None,
-        role="role"
+        role="role",
+        handle_offer_callback=mesos_executor.handle_offer,
     )
 
-    msd = me_module.MesosSchedulerDriver.return_value
-    assert mesos_executor.driver is msd
-    assert me_module.MesosSchedulerDriver.call_args == mock.call(
-        sched=ef,
-        framework=ef.framework_info,
+    assert mesos_executor.driver is mesos_driver.return_value
+    assert mesos_driver.call_args == mock.call(
+        sched=execution_framework.return_value,
+        framework=execution_framework.return_value.framework_info,
         use_addict=True,
         master_uri='127.0.0.1:5050',
         implicit_acknowledgements=False,

--- a/tests/unit/plugins/mesos/mesos_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_executor_test.py
@@ -2,11 +2,13 @@ import mock
 import pytest
 
 from task_processing.plugins.mesos.mesos_executor import AbstractMesosExecutor
-from task_processing.plugins.mesos.translator import mesos_status_to_event
 
 
 class DummyMesosExecutor(AbstractMesosExecutor):
-    def handle_offer(task_configs, offer):
+    def get_tasks_for_offer(self, task_configs, offer):
+        pass
+
+    def process_status_update(self, update, task_config):
         pass
 
 
@@ -28,10 +30,9 @@ def test_creates_execution_framework_and_driver(mock_Thread, mesos_executor, moc
         name="taskproc-default",
         task_staging_timeout_s=240,
         initial_decline_delay=1.0,
-        translator=mesos_status_to_event,
         pool=None,
         role="role",
-        handle_offer_callback=mesos_executor.handle_offer,
+        callback_interface=mesos_executor,
     )
 
     assert mesos_executor.driver is mesos_driver.return_value

--- a/tests/unit/plugins/mesos/mesos_task_config_test.py
+++ b/tests/unit/plugins/mesos/mesos_task_config_test.py
@@ -1,6 +1,6 @@
 from pyrsistent import InvariantException
 
-from task_processing.plugins.mesos.mesos_executor import MesosTaskConfig
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
 
 
 def test_mesos_task_config_factories():

--- a/tests/unit/plugins/mesos/mesos_task_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_task_executor_test.py
@@ -32,11 +32,14 @@ def resource_patches():
 
 
 @pytest.mark.parametrize('fits,constraints', [(False, True), (True, False)])
-def test_handle_offer_doesnt_fit(mesos_task_executor, resource_patches, fits, constraints):
+def test_get_tasks_for_offer_doesnt_fit(mesos_task_executor, resource_patches, fits, constraints):
     mock_fits, mock_constraints, mock_allocate, mock_make_task = resource_patches
     mock_fits.return_value = fits
     mock_constraints.return_value = constraints
-    tasks_to_launch, tasks_to_defer = mesos_task_executor.handle_offer([mock.Mock()], mock.Mock())
+    tasks_to_launch, tasks_to_defer = mesos_task_executor.get_tasks_for_offer(
+        [mock.Mock()],
+        mock.Mock(),
+    )
 
     assert mock_allocate.call_count == 0
     assert mock_make_task.call_count == 0
@@ -44,12 +47,15 @@ def test_handle_offer_doesnt_fit(mesos_task_executor, resource_patches, fits, co
     assert len(tasks_to_defer) == 1
 
 
-def test_handle_offer(mesos_task_executor, resource_patches):
+def test_get_tasks_for_offer(mesos_task_executor, resource_patches):
     _, _, mock_allocate, mock_make_task = resource_patches
     fake_mesos_task_info = mock.Mock()
     mock_allocate.return_value = mock.Mock(), []
     mock_make_task.return_value = fake_mesos_task_info
-    tasks_to_launch, tasks_to_defer = mesos_task_executor.handle_offer([mock.Mock()], mock.Mock())
+    tasks_to_launch, tasks_to_defer = mesos_task_executor.get_tasks_for_offer(
+        [mock.Mock()],
+        mock.Mock(),
+    )
 
     assert mock_allocate.call_count == 1
     assert mock_make_task.call_count == 1

--- a/tests/unit/plugins/mesos/mesos_task_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_task_executor_test.py
@@ -1,0 +1,57 @@
+import mock
+import pytest
+
+from task_processing.plugins.mesos.mesos_task_executor import MesosTaskExecutor
+
+
+@pytest.fixture
+def mesos_task_executor(request, mock_Thread, mock_fw_and_driver):
+    executor = MesosTaskExecutor('role')
+
+    def mesos_executor_teardown():
+        executor.stop()
+    request.addfinalizer(mesos_executor_teardown)
+
+    return executor
+
+
+@pytest.fixture
+def resource_patches():
+    with mock.patch(
+        'task_processing.plugins.mesos.mesos_task_executor.get_offer_resources',
+    ), mock.patch(
+        'task_processing.plugins.mesos.mesos_task_executor.task_fits',
+    ) as mock_fits, mock.patch(
+        'task_processing.plugins.mesos.mesos_task_executor.offer_matches_task_constraints',
+    ) as mock_constraints, mock.patch(
+        'task_processing.plugins.mesos.mesos_task_executor.allocate_task_resources',
+    ) as mock_allocate, mock.patch(
+        'task_processing.plugins.mesos.mesos_task_executor.make_mesos_task_info',
+    ) as mock_make_task:
+        yield mock_fits, mock_constraints, mock_allocate, mock_make_task
+
+
+@pytest.mark.parametrize('fits,constraints', [(False, True), (True, False)])
+def test_handle_offer_doesnt_fit(mesos_task_executor, resource_patches, fits, constraints):
+    mock_fits, mock_constraints, mock_allocate, mock_make_task = resource_patches
+    mock_fits.return_value = fits
+    mock_constraints.return_value = constraints
+    tasks_to_launch, tasks_to_defer = mesos_task_executor.handle_offer([mock.Mock()], mock.Mock())
+
+    assert mock_allocate.call_count == 0
+    assert mock_make_task.call_count == 0
+    assert len(tasks_to_launch) == 0
+    assert len(tasks_to_defer) == 1
+
+
+def test_handle_offer(mesos_task_executor, resource_patches):
+    _, _, mock_allocate, mock_make_task = resource_patches
+    fake_mesos_task_info = mock.Mock()
+    mock_allocate.return_value = mock.Mock(), []
+    mock_make_task.return_value = fake_mesos_task_info
+    tasks_to_launch, tasks_to_defer = mesos_task_executor.handle_offer([mock.Mock()], mock.Mock())
+
+    assert mock_allocate.call_count == 1
+    assert mock_make_task.call_count == 1
+    assert tasks_to_launch == [fake_mesos_task_info]
+    assert len(tasks_to_defer) == 0

--- a/tests/unit/plugins/mesos/mesos_task_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_task_executor_test.py
@@ -1,63 +1,48 @@
 import mock
 import pytest
 
-from task_processing.plugins.mesos.mesos_task_executor import MesosTaskExecutor
-
-
-@pytest.fixture
-def mesos_task_executor(request, mock_Thread, mock_fw_and_driver):
-    executor = MesosTaskExecutor('role')
-
-    def mesos_executor_teardown():
-        executor.stop()
-    request.addfinalizer(mesos_executor_teardown)
-
-    return executor
+from task_processing.plugins.mesos.mesos_task_executor import get_tasks_for_offer
 
 
 @pytest.fixture
 def resource_patches():
     with mock.patch(
-        'task_processing.plugins.mesos.mesos_task_executor.get_offer_resources',
-    ), mock.patch(
         'task_processing.plugins.mesos.mesos_task_executor.task_fits',
     ) as mock_fits, mock.patch(
-        'task_processing.plugins.mesos.mesos_task_executor.offer_matches_task_constraints',
+        'task_processing.plugins.mesos.mesos_task_executor.attributes_match_constraints',
     ) as mock_constraints, mock.patch(
         'task_processing.plugins.mesos.mesos_task_executor.allocate_task_resources',
-    ) as mock_allocate, mock.patch(
-        'task_processing.plugins.mesos.mesos_task_executor.make_mesos_task_info',
-    ) as mock_make_task:
-        yield mock_fits, mock_constraints, mock_allocate, mock_make_task
+    ) as mock_allocate:
+        yield mock_fits, mock_constraints, mock_allocate
 
 
 @pytest.mark.parametrize('fits,constraints', [(False, True), (True, False)])
-def test_get_tasks_for_offer_doesnt_fit(mesos_task_executor, resource_patches, fits, constraints):
-    mock_fits, mock_constraints, mock_allocate, mock_make_task = resource_patches
+def test_get_tasks_for_offer_doesnt_fit(resource_patches, fits, constraints):
+    mock_fits, mock_constraints, mock_allocate = resource_patches
     mock_fits.return_value = fits
     mock_constraints.return_value = constraints
-    tasks_to_launch, tasks_to_defer = mesos_task_executor.get_tasks_for_offer(
+    tasks_to_launch, tasks_to_defer = get_tasks_for_offer(
         [mock.Mock()],
         mock.Mock(),
+        mock.Mock(),
+        'role',
     )
 
     assert mock_allocate.call_count == 0
-    assert mock_make_task.call_count == 0
     assert len(tasks_to_launch) == 0
     assert len(tasks_to_defer) == 1
 
 
-def test_get_tasks_for_offer(mesos_task_executor, resource_patches):
-    _, _, mock_allocate, mock_make_task = resource_patches
-    fake_mesos_task_info = mock.Mock()
+def test_get_tasks_for_offer(resource_patches):
+    _, _, mock_allocate = resource_patches
     mock_allocate.return_value = mock.Mock(), []
-    mock_make_task.return_value = fake_mesos_task_info
-    tasks_to_launch, tasks_to_defer = mesos_task_executor.get_tasks_for_offer(
+    tasks_to_launch, tasks_to_defer = get_tasks_for_offer(
         [mock.Mock()],
         mock.Mock(),
+        mock.Mock(),
+        'role',
     )
 
     assert mock_allocate.call_count == 1
-    assert mock_make_task.call_count == 1
-    assert tasks_to_launch == [fake_mesos_task_info]
+    assert len(tasks_to_launch) == 1
     assert len(tasks_to_defer) == 0

--- a/tests/unit/plugins/mesos/resource_helpers_test.py
+++ b/tests/unit/plugins/mesos/resource_helpers_test.py
@@ -37,13 +37,7 @@ def test_allocate_task_resources(fake_task, offer_resources, available_ports):
     offer_resources = offer_resources.set('ports', available_ports)
     expected_port = available_ports[0].begin
     consumed, remaining = allocate_task_resources(fake_task, offer_resources)
-    assert consumed == {
-        'cpus': 10,
-        'mem': 1024,
-        'disk': 1000,
-        'gpus': 1,
-        'ports': v(expected_port),
-    }
+    assert consumed == fake_task.set(ports=v(m(begin=expected_port, end=expected_port)))
     assert remaining == {
         'cpus': 0,
         'mem': 0,

--- a/tests/unit/plugins/mesos/retrying_executor_test.py
+++ b/tests/unit/plugins/mesos/retrying_executor_test.py
@@ -5,8 +5,8 @@ import mock
 import pytest
 
 from task_processing.interfaces.event import Event
-from task_processing.plugins.mesos.mesos_executor import MesosTaskConfig
 from task_processing.plugins.mesos.retrying_executor import RetryingExecutor
+from task_processing.plugins.mesos.task_config import MesosTaskConfig
 # from task_processing.plugins.mesos.translator import mesos_status_to_event
 
 

--- a/tests/unit/plugins/mesos/translator_test.py
+++ b/tests/unit/plugins/mesos/translator_test.py
@@ -4,7 +4,6 @@ import pytest
 from pyrsistent import v
 
 from task_processing.interfaces.event import Event
-from task_processing.plugins.mesos.resource_helpers import ResourceSet
 from task_processing.plugins.mesos.translator import make_mesos_task_info
 from task_processing.plugins.mesos.translator import MESOS_STATUS_MAP
 from task_processing.plugins.mesos.translator import mesos_update_to_event
@@ -52,7 +51,6 @@ def test_make_mesos_task_info(
     containerizer,
     container,
 ):
-    consumed_resources = ResourceSet(cpus=10, mem=1024, disk=1000, gpus=gpus_count, ports=v(31200))
     tid = fake_task.task_id
     fake_task = fake_task.set(
         volumes=v(
@@ -68,8 +66,7 @@ def test_make_mesos_task_info(
 
     task_info = make_mesos_task_info(
         fake_task,
-        consumed_resources,
-        fake_offer,
+        fake_offer.agent_id.value,
         'fake_role',
     )
 

--- a/tests/unit/plugins/mesos/translator_test.py
+++ b/tests/unit/plugins/mesos/translator_test.py
@@ -1,13 +1,127 @@
-from unittest.mock import MagicMock
+import addict
+import mock
+import pytest
+from pyrsistent import v
 
 from task_processing.interfaces.event import Event
+from task_processing.plugins.mesos.resource_helpers import ResourceSet
+from task_processing.plugins.mesos.translator import make_mesos_task_info
 from task_processing.plugins.mesos.translator import MESOS_STATUS_MAP
 from task_processing.plugins.mesos.translator import mesos_status_to_event
 
 
+@pytest.mark.parametrize('gpus_count,containerizer,container', [
+    (1.0, 'MESOS', addict.Dict(
+        type='MESOS',
+        volumes=[addict.Dict(
+            container_path='fake_container_path',
+            host_path='fake_host_path',
+            mode='RO'
+        )],
+        mesos=addict.Dict(
+            image=addict.Dict(
+                type='DOCKER',
+                docker=addict.Dict(name='fake_image'),
+                cached=True,
+            ),
+        ),
+        network_infos=addict.Dict(
+            port_mappings=[addict.Dict(host_port=31200, container_port=8888)],
+        ),
+    )),
+    (0, 'DOCKER', addict.Dict(
+        type='DOCKER',
+        volumes=[addict.Dict(
+            container_path='fake_container_path',
+            host_path='fake_host_path',
+            mode='RO'
+        )],
+        docker=addict.Dict(
+            image='fake_image',
+            network='BRIDGE',
+            force_pull_image=False,
+            port_mappings=[addict.Dict(host_port=31200, container_port=8888)],
+            parameters=[],
+        ),
+    )),
+])
+def test_make_mesos_task_info(
+    fake_task,
+    fake_offer,
+    gpus_count,
+    containerizer,
+    container,
+):
+    consumed_resources = ResourceSet(cpus=10, mem=1024, disk=1000, gpus=gpus_count, ports=v(31200))
+    tid = fake_task.task_id
+    fake_task = fake_task.set(
+        volumes=v(
+            addict.Dict(
+                mode='RO',
+                container_path='fake_container_path',
+                host_path='fake_host_path'
+            )
+        ),
+        gpus=gpus_count,
+        containerizer=containerizer,
+    )
+
+    task_info = make_mesos_task_info(
+        fake_task,
+        consumed_resources,
+        fake_offer,
+        'fake_role',
+    )
+
+    expected_task_info = addict.Dict(
+        task_id=addict.Dict(value=tid),
+        agent_id=addict.Dict(value='fake_agent_id'),
+        name='executor-{id}'.format(id=tid),
+        resources=[
+            addict.Dict(
+                name='cpus',
+                type='SCALAR',
+                role='fake_role',
+                scalar=addict.Dict(value=10.0)
+            ),
+            addict.Dict(
+                name='mem',
+                type='SCALAR',
+                role='fake_role',
+                scalar=addict.Dict(value=1024.0)
+            ),
+            addict.Dict(
+                name='disk',
+                type='SCALAR',
+                role='fake_role',
+                scalar=addict.Dict(value=1000.0)
+            ),
+            addict.Dict(
+                name='gpus',
+                type='SCALAR',
+                role='fake_role',
+                scalar=addict.Dict(value=gpus_count)
+            ),
+            addict.Dict(
+                name='ports',
+                type='RANGES',
+                role='fake_role',
+                ranges=addict.Dict(range=[addict.Dict(begin=31200, end=31200)]),
+            ),
+        ],
+        command=addict.Dict(
+            value='echo "fake"',
+            uris=[],
+            environment=addict.Dict(variables=[])
+        ),
+        container=container,
+    )
+    assert task_info == expected_task_info
+
+
 def test_translator_maps_status_to_event():
     for k in MESOS_STATUS_MAP:
-        mesos_status = MagicMock()
+        mesos_status = mock.MagicMock()
         mesos_status.state = k
         assert isinstance(
             mesos_status_to_event(mesos_status, 123, task_config={}),


### PR DESCRIPTION
This change pulls some logic out of the execution framework into the executor, in preparation for pods support.  To support having different executor objects for pods and non-pods, the MesosExecutor now expects a set of callbacks to be passed in to describe how to handle various pod/task use cases.  I created two subclasses of `MesosExecutor` which fill in these callbacks appropriately for "bare" tasks and pods (actually the pods executor is not implemented yet).

Currently we just support task creation and handling Mesos updates; we will also need to handle killing tasks, but in order to support that I'm going to want to move the task_metadata field from the execution framework into the executor.  That's going to be a bigger change so I'm going to put up a separate review for that once this one's shipped.

In addition to the above, the following changes were made:

1. pulled out list of SFX metrics into its own file for easier importing
2. at line 448 (new) of execution_framework.py, I removed the check if the queue is empty.  This is a duplicate check, and is already taken care of in line 362 (new).  
3. added a `use_cached_image` flag for the `MesosTaskConfig`; before this was set to _always_ re-download docker images when using the Docker containerizer, but was set to used cached images for the Mesos containerizer.  This allows the user to specify which to use.
4. clean up some tests, particularly in execution_framework_test.py