### PR TITLE
Access metadata for reconciliation inside lock

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -122,8 +122,12 @@ class ExecutionFramework(Scheduler):
                 return
 
             time_now = time.time()
+            tasks_to_reconcile = []
             with self._lock:
                 for task_id, md in self.task_metadata.items():
+                    if md.task_state != 'TASK_INITED':
+                        tasks_to_reconcile.append(task_id)
+
                     if md.task_state == 'TASK_INITED':
                         # give up if the task hasn't launched after
                         # offer_timeout
@@ -186,9 +190,7 @@ class ExecutionFramework(Scheduler):
 
             self._reconcile_tasks(
                 [Dict({'task_id': Dict({'value': task_id})}) for
-                    task_id in self.task_metadata
-                 if self.task_metadata[task_id].task_state is not
-                 'TASK_INITED']
+                    task_id in tasks_to_reconcile]
             )
             time.sleep(10)
 


### PR DESCRIPTION
Internal ticket TASKPROC-209

Stack trace indicates that the keys in task_metadata are changing as we iterate over it.

```
Exception in thread Thread-5:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/venvs/jolt/lib/python3.6/site-packages/task_processing/plugins/mesos/execution_framework.py", line 178, in _background_check
    task_id in self.task_metadata
  File "/opt/venvs/jolt/lib/python3.6/site-packages/task_processing/plugins/mesos/execution_framework.py", line 179, in <listcomp>
    if self.task_metadata[task_id].task_state is not
  File "/opt/venvs/jolt/lib/python3.6/site-packages/pyrsistent/_pmap.py", line 68, in __getitem__
    return PMap._getitem(self._buckets, key)
  File "/opt/venvs/jolt/lib/python3.6/site-packages/pyrsistent/_pmap.py", line 65, in _getitem
    raise KeyError(key)
KeyError: 'executor-918.b2e00cfd-5dbc-43fe-be45-66d430c09152-retry3'
```