### PR TITLE
Save driver in more places

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -432,6 +432,8 @@ class ExecutionFramework(Scheduler):
         ))
 
     def reregistered(self, driver, masterInfo):
+        if self._driver is None:
+            self._driver = driver
         log.warning("Re-registered to {master} with role {role}".format(
             master=masterInfo,
             role=self.role
@@ -569,6 +571,9 @@ class ExecutionFramework(Scheduler):
             log.info("Offers accepted: {}".format(', '.join(accepted)))
 
     def statusUpdate(self, driver, update) -> None:
+        if self._driver is None:
+            self._driver = driver
+
         task_id = update.task_id.value
         task_state = str(update.state)
 


### PR DESCRIPTION
Ran into a bug where Tron couldn't do anything (reconciling, starting new tasks) after starting up because it didn't have the driver.

The driver is also saved in resourceOffers, which is how this worked before, but I happened to be testing this when our Mesos cluster was having an issue and not sending any offers.