### PR TITLE
Don't raise exception if running task is missing

### DIFF
--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -171,6 +171,10 @@ class MesosLoggingExecutor(TaskExecutor):
                     self.staging_tasks = self.staging_tasks.set(e.task_id, url)
 
                 if e.kind == 'task' and e.platform_type == 'running':
+                    if e.task_id not in self.staging_tasks:
+                        log.info(f"Task {e.task_id} already running, not fetching logs")
+                        continue
+
                     url = self.staging_tasks[e.task_id]
                     self.staging_tasks = self.staging_tasks.discard(e.task_id)
 

--- a/tests/unit/plugins/mesos/logging_executor_test.py
+++ b/tests/unit/plugins/mesos/logging_executor_test.py
@@ -1,5 +1,8 @@
+from queue import Queue
+
 import mock
 import pytest
+from addict import Dict
 
 from task_processing.plugins.mesos.logging_executor import MesosLoggingExecutor
 from task_processing.plugins.mesos.task_config import MesosTaskConfig
@@ -12,8 +15,15 @@ def mock_Thread():
 
 
 @pytest.fixture
-def mock_downstream():
-    return mock.MagicMock()
+def source_queue():
+    return Queue()
+
+
+@pytest.fixture
+def mock_downstream(source_queue):
+    executor = mock.MagicMock()
+    executor.get_event_queue.return_value = source_queue
+    return executor
 
 
 @pytest.fixture
@@ -42,3 +52,100 @@ def test_stop(mock_logging_executor, mock_downstream):
     mock_logging_executor.stop()
     assert mock_downstream.stop.call_args == mock.call()
     assert mock_logging_executor.stopping
+
+
+def test_event_loop_stores_staging_event(mock_logging_executor, source_queue):
+    raw = Dict({
+        'offer': {
+            'url': {
+                'scheme': 'http',
+                'address': {
+                    'ip': '1.2.3.4',
+                    'port': 5051,
+                },
+            },
+        },
+    })
+    mock_event = mock.Mock(
+        kind='task',
+        platform_type='staging',
+        task_id='my_task',
+        raw=raw,
+    )
+
+    mock_logging_executor.stopping = True
+    source_queue.put(mock_event)
+
+    mock_logging_executor.event_loop()
+    task_data = mock_logging_executor.staging_tasks['my_task']
+    assert task_data == 'http://1.2.3.4:5051'
+
+
+def test_event_loop_continues_after_unknown_task(mock_logging_executor, source_queue):
+    unknown_event = mock.Mock(
+        kind='task',
+        platform_type='running',
+        task_id='new_task',
+    )
+    other_event = mock.Mock(
+        kind='task',
+        platform_type='something',
+        task_id='other_task',
+    )
+
+    mock_logging_executor.stopping = True
+    source_queue.put(unknown_event)
+    source_queue.put(other_event)
+
+    mock_logging_executor.event_loop()
+
+    dest_queue = mock_logging_executor.get_event_queue()
+    assert dest_queue.get() == unknown_event
+    assert dest_queue.get() == other_event
+
+
+def test_event_loop_running_event(mock_logging_executor, source_queue):
+    raw = Dict({
+        'container_status': {
+            'container_id': {
+                'value': 'cid',
+            },
+        },
+        'executor_id': {
+            'value': 'eid',
+        },
+    })
+    mock_event = mock.Mock(
+        kind='task',
+        platform_type='running',
+        task_id='my_task',
+        raw=raw,
+    )
+
+    mock_logging_executor.stopping = True
+    source_queue.put(mock_event)
+    mock_logging_executor.staging_tasks = mock_logging_executor.staging_tasks.set(
+        'my_task', 'my_log_url')
+
+    mock_logging_executor.event_loop()
+    assert 'my_task' in mock_logging_executor.running_tasks
+    assert 'my_task' not in mock_logging_executor.staging_tasks
+
+
+def test_event_loop_terminal_event(mock_logging_executor, source_queue):
+    mock_event = mock.Mock(
+        kind='task',
+        platform_type='finished',
+        task_id='my_task',
+        terminal=True,
+    )
+
+    mock_logging_executor.stopping = True
+    source_queue.put(mock_event)
+    mock_logging_executor.running_tasks = mock_logging_executor.running_tasks.set(
+        'my_task', mock.Mock())
+
+    mock_logging_executor.event_loop()
+
+    assert 'my_task' in mock_logging_executor.running_tasks
+    assert 'my_task' in mock_logging_executor.done_tasks


### PR DESCRIPTION
The task_id may not be in `self.staging_tasks` if we have restarted and are receiving reconciliation events. We want the thread to continue processing events. Also added some tests for the logging executor.

I wanted to fetch logs again, but given the TASK_RUNNING update only has the agent_id, it doesn't seem possible to get the agent_url back. (We don't have the master url anywhere, to get the agent url from the agent id.) This is an example of the update:
```
{
'agent_id': {'value': '2bd4b611-9206-47ca-a64d-7b7a2973b9e0-S1'}, 
'container_status': {
  'container_id': {'value': '...'}, 
  'network_infos': [{
      'ip_addresses': [{'ip_address': '169.254.0.1', 'protocol': 'IPv4'}]
    }]
},
'data': '...', 
'executor_id': {'value': 'MASTER.test.1.first.930ec85b-10a5-43e9-8970-05fee5a1d247'}, 
'labels': {'labels': [{'key': 'Docker.NetworkSettings.IPAddress', 'value': '169.254.0.1'}]}, 
'source': 'SOURCE_EXECUTOR',
'state': 'TASK_RUNNING',
'task_id': {'value': 'MASTER.test.1.first.930ec85b-10a5-43e9-8970-05fee5a1d247'},
'timestamp': 1536190686.70458,
'uuid': '/IHnK8J5QuGNggG0uolaDA=='
}
```