### PR TITLE
Modify timeout and retrying executors to allow missing tasks to reregister during reconciliation

### DIFF
--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -172,7 +172,8 @@ class MesosLoggingExecutor(TaskExecutor):
 
                 if e.kind == 'task' and e.platform_type == 'running':
                     if e.task_id not in self.staging_tasks:
-                        log.info(f"Task {e.task_id} already running, not fetching logs")
+                        log.info(
+                            f"Task {e.task_id} already running, not fetching logs")
                         continue
 
                     url = self.staging_tasks[e.task_id]

--- a/task_processing/plugins/mesos/timeout_executor.py
+++ b/task_processing/plugins/mesos/timeout_executor.py
@@ -90,7 +90,8 @@ class TimeoutExecutor(TaskExecutor):
     def run(self, task_config):
         # Tasks are dynamically added and removed from running_tasks and
         # and killed_tasks. It's preferable for the client or execution
-        # framework to check for duplicated tasks.
+        # framework to check for duplicated tasks. The duplicate task check does
+        # NOT happen here.
         new_entry = TaskEntry(
             task_id=task_config.task_id,
             deadline=task_config.timeout + time.time()

--- a/tests/unit/plugins/mesos/retrying_executor_test.py
+++ b/tests/unit/plugins/mesos/retrying_executor_test.py
@@ -6,7 +6,6 @@ import pytest
 from task_processing.interfaces.event import Event
 from task_processing.plugins.mesos.retrying_executor import RetryingExecutor
 from task_processing.plugins.mesos.task_config import MesosTaskConfig
-# from task_processing.plugins.mesos.translator import mesos_status_to_event
 
 
 @pytest.fixture
@@ -16,8 +15,15 @@ def mock_Thread():
 
 
 @pytest.fixture
-def mock_downstream():
-    return mock.Mock()
+def source_queue():
+    return Queue()
+
+
+@pytest.fixture
+def mock_downstream(source_queue):
+    executor = mock.MagicMock()
+    executor.get_event_queue.return_value = source_queue
+    return executor
 
 
 @pytest.fixture
@@ -28,27 +34,35 @@ def mock_retrying_executor(mock_Thread, mock_downstream):
     )
 
 
-def _get_mock_task_config():
-    return MesosTaskConfig(image='mock_image', cmd='mock_cmd', retries=5)
+@pytest.fixture
+def mock_task_config():
+    return MesosTaskConfig(
+        uuid='mock_uuid',
+        name='mock_name',
+        image='mock_image',
+        cmd='mock_cmd',
+        retries=5,
+    )
 
 
-def _get_mock_event(is_terminal=False):
-    mock_config = _get_mock_task_config()
+@pytest.fixture
+def mock_event(mock_task_config, is_terminal=False):
     return Event(
         kind='task',
         timestamp=1234.5678,
         terminal=is_terminal,
         success=False,
-        task_id=mock_config.task_id,
+        task_id=mock_task_config.task_id,
         platform_type='mesos',
         message='mock_message',
-        task_config=mock_config,
+        task_config=mock_task_config,
         raw='raw_event'
     )
 
+# task_retry ###################################################################
 
-def test_task_retry(mock_retrying_executor):
-    mock_event = _get_mock_event()
+
+def test_task_retry(mock_retrying_executor, mock_event):
     mock_retrying_executor.task_retries = mock_retrying_executor.\
         task_retries.set(mock_event.task_id, 3)
     mock_retrying_executor.run = mock.Mock()
@@ -59,114 +73,26 @@ def test_task_retry(mock_retrying_executor):
     assert mock_retrying_executor.run.call_count == 1
 
 
-def test_retries_exhaused(mock_retrying_executor):
-    mock_event = _get_mock_event()
+def test_task_retry_retries_exhausted(mock_retrying_executor, mock_event):
     mock_retrying_executor.task_retries = mock_retrying_executor.\
-        task_retries.set(mock_event.task_id, 1)
+        task_retries.set(mock_event.task_id, 0)
     mock_retrying_executor.run = mock.Mock()
 
-    mock_retrying_executor.retry(mock_event)
+    retry_attempted = mock_retrying_executor.retry(mock_event)
 
     assert mock_retrying_executor.task_retries[mock_event.task_id] == 0
-    assert mock_retrying_executor.run.call_count == 1
+    assert mock_retrying_executor.run.call_count == 0
+    assert not retry_attempted
+
+# retry_loop ###################################################################
 
 
-def test_task_config_with_retry(mock_retrying_executor):
-    mock_task_config = _get_mock_task_config()
-    mock_retrying_executor.task_retries = mock_retrying_executor.\
-        task_retries.set(mock_task_config.task_id, 2)
-
-    ret_value = mock_retrying_executor._task_config_with_retry(
-        mock_task_config
-    )
-
-    assert '-retry2' in ret_value.task_id
-
-
-def test_restore_task_id(mock_retrying_executor):
-    mock_event = _get_mock_event()
-    original_task_id = mock_event.task_id
-    mock_retrying_executor.task_retries = mock_retrying_executor.\
-        task_retries.set(mock_event.task_id, 1)
-    task_config = mock_event.task_config
-    modified_task_config = task_config.set(
-        'uuid',
-        str(mock_event.task_config.uuid) + '-retry1'
-    )
-    mock_event = mock_event.set(
-        'task_config',
-        modified_task_config
-    )
-
-    ret_value = mock_retrying_executor._restore_task_id(
-        mock_event,
-        original_task_id
-    )
-
-    assert mock_event.task_id == ret_value.task_id
-
-
-def test_is_not_current_attempt(mock_retrying_executor):
-    mock_event = _get_mock_event()
-    original_task_id = mock_event.task_id
-    mock_retrying_executor.task_retries = mock_retrying_executor.\
-        task_retries.set(mock_event.task_id, 2)
-    task_config = mock_event.task_config
-    modified_task_id = str(mock_event.task_config.uuid) + '-retry1'
-    modified_task_config = task_config.set(
-        'uuid',
-        modified_task_id
-    )
-    modified_mock_event = mock_event.set(
-        'task_config',
-        modified_task_config
-    )
-    modified_mock_event = mock_event.set(
-        'task_id',
-        modified_task_id
-    )
-
-    ret_value = mock_retrying_executor._is_current_attempt(
-        modified_mock_event,
-        original_task_id
-    )
-
-    assert ret_value is False
-
-
-def test_is_current_attempt(mock_retrying_executor):
-    mock_event = _get_mock_event()
-    original_task_id = mock_event.task_id
-    mock_retrying_executor.task_retries = mock_retrying_executor.\
-        task_retries.set(mock_event.task_id, 2)
-    task_config = mock_event.task_config
-    modified_task_id = str(mock_event.task_config.uuid) + '-retry2'
-    modified_task_config = task_config.set(
-        'uuid',
-        modified_task_id
-    )
-    modified_mock_event = mock_event.set(
-        'task_config',
-        modified_task_config
-    )
-    modified_mock_event = mock_event.set(
-        'task_id',
-        modified_task_id
-    )
-
-    ret_value = mock_retrying_executor._is_current_attempt(
-        modified_mock_event,
-        original_task_id
-    )
-
-    assert ret_value is True
-
-
-def test_retry_loop_retries_task(mock_retrying_executor):
-    mock_event = _get_mock_event()
+def test_retry_loop_retries_task(mock_retrying_executor, mock_event):
+    mock_event = mock_event.set('terminal', True)
     mock_retrying_executor.stopping = True
     mock_retrying_executor._is_current_attempt = mock.Mock(return_value=True)
-    mock_retrying_executor.event_with_retries = mock.Mock()
+    mock_retrying_executor._restore_task_id = mock.Mock(
+        return_value=mock_event)
     mock_retrying_executor.retry = mock.Mock(return_value=True)
     mock_retrying_executor.retry_pred = mock.Mock(return_value=True)
     mock_retrying_executor.src_queue = Queue()
@@ -177,10 +103,11 @@ def test_retry_loop_retries_task(mock_retrying_executor):
     mock_retrying_executor.retry_loop()
 
     assert mock_retrying_executor.dest_queue.qsize() == 0
+    assert mock_retrying_executor.retry.call_count == 1
 
 
-def test_retry_loop_does_not_retry_task(mock_retrying_executor):
-    mock_event = _get_mock_event(is_terminal=True)
+def test_retry_loop_does_not_retry_task(mock_retrying_executor, mock_event):
+    mock_event = mock_event.set('terminal', True)
     mock_retrying_executor.stopping = True
     mock_retrying_executor._is_current_attempt = mock.Mock(return_value=True)
     mock_retrying_executor.retry = mock.Mock(return_value=False)
@@ -212,28 +139,51 @@ def test_retry_loop_filters_out_non_task(mock_retrying_executor):
     mock_retrying_executor.stopping = True
     mock_retrying_executor._is_current_attempt = mock.Mock(return_value=True)
     mock_retrying_executor.event_with_retries = mock.Mock()
-    mock_retrying_executor.retry = mock.Mock(return_value=True)
-    mock_retrying_executor.retry_pred = mock.Mock(return_value=True)
+    mock_retrying_executor.retry = mock.Mock()
     mock_retrying_executor.src_queue = Queue()
     mock_retrying_executor.src_queue.put(mock_event)
 
     mock_retrying_executor.retry_loop()
 
     assert mock_retrying_executor.dest_queue.qsize() == 1
+    assert mock_retrying_executor.retry.call_count == 0
 
 
-def test_run(mock_retrying_executor, mock_downstream):
-    mock_config = _get_mock_task_config()
-    mock_retrying_executor.run(mock_config)
+# If retrying_executor receives an event about an attempt for a task the
+# executor does not know about, it should add the task into task_retries
+# and assume the event's attempt is the current attempt
+def test_retry_loop_recover_attempt(mock_retrying_executor, mock_event):
+    original_task_id = mock_event.task_id
+    modified_mock_event = mock_event.set(
+        'task_id',
+        original_task_id + '-retry6'
+    )
+    modified_mock_event = modified_mock_event.set('terminal', True)
+    mock_retrying_executor.stopping = True
+    mock_retrying_executor.retry = mock.Mock(return_value=True)
+    mock_retrying_executor.retry_pred = mock.Mock(return_value=True)
+    mock_retrying_executor.src_queue = Queue()
+    mock_retrying_executor.src_queue.put(modified_mock_event)
+
+    mock_retrying_executor.retry_loop()
+
+    assert mock_retrying_executor.dest_queue.qsize() == 0
+    assert mock_retrying_executor.retry.call_count == 1
+    assert mock_retrying_executor.task_retries[original_task_id] == 6
+
+
+# run ##########################################################################
+def test_run(mock_retrying_executor, mock_downstream, mock_task_config):
+    mock_retrying_executor.run(mock_task_config)
+
     assert mock_downstream.run.call_count == 1
-
-    assert mock_retrying_executor.task_retries[mock_config.task_id] == 5
+    assert mock_retrying_executor.task_retries[mock_task_config.task_id] == 5
 
     # Config should be the same, except with retry number appended
     config_with_retry = mock_downstream.run.call_args[0][0]
-    assert 'retry5' in config_with_retry.task_id
-    assert config_with_retry.cmd == mock_config.cmd
-    assert config_with_retry.image == mock_config.image
+    assert config_with_retry.task_id == mock_task_config.task_id + '-retry5'
+    assert config_with_retry.cmd == mock_task_config.cmd
+    assert config_with_retry.image == mock_task_config.image
 
 
 def test_run_default_retries(mock_retrying_executor, mock_downstream):
@@ -244,19 +194,141 @@ def test_run_default_retries(mock_retrying_executor, mock_downstream):
     assert mock_retrying_executor.task_retries[mock_config.task_id] == 2
 
 
+# reconcile ####################################################################
+def test_reconcile(mock_retrying_executor, mock_downstream):
+    mock_retrying_executor.reconcile("task")
+
+    assert mock_downstream.reconcile.call_args == mock.call("task")
+
+
+# kill #########################################################################
 def test_kill(mock_retrying_executor, mock_downstream):
     result = mock_retrying_executor.kill("task")
+
     assert result == mock_downstream.kill.return_value
     assert mock_downstream.kill.call_args == mock.call("task")
     assert mock_retrying_executor.task_retries["task"] == -1
 
 
-def test_reconcile(mock_retrying_executor, mock_downstream):
-    mock_retrying_executor.reconcile("task")
-    assert mock_downstream.reconcile.call_args == mock.call("task")
-
-
+# stop #########################################################################
 def test_stop(mock_retrying_executor, mock_downstream):
     mock_retrying_executor.stop()
+
     assert mock_downstream.stop.call_args == mock.call()
-    assert mock_retrying_executor.stopping
+    assert mock_retrying_executor.stopping is True
+
+
+# _task_config_with_retry ######################################################
+def test_task_config_with_retry(mock_retrying_executor, mock_task_config):
+    mock_retrying_executor.task_retries = mock_retrying_executor.\
+        task_retries.set(mock_task_config.task_id, 2)
+
+    ret_value = mock_retrying_executor._task_config_with_retry(
+        mock_task_config
+    )
+
+    assert ret_value.task_id == mock_task_config.task_id + '-retry2'
+
+
+# _restore_task_id #############################################################
+def test_restore_task_id(mock_retrying_executor, mock_event):
+    original_task_id = mock_event.task_id
+    mock_retrying_executor.task_retries = mock_retrying_executor.\
+        task_retries.set(mock_event.task_id, 1)
+    modified_task_config = mock_event.task_config.set(
+        'uuid',
+        str(mock_event.task_config.uuid) + '-retry1'
+    )
+    mock_event = mock_event.set(
+        'task_config',
+        modified_task_config
+    )
+
+    ret_value = mock_retrying_executor._restore_task_id(
+        mock_event,
+        original_task_id
+    )
+
+    assert mock_event.task_id == ret_value.task_id
+
+
+# _is_current_attempt ##########################################################
+def test_is_current_attempt(
+    mock_retrying_executor,
+    mock_event,
+    mock_task_config,
+):
+    original_task_id = mock_event.task_id
+    mock_retrying_executor.task_retries = mock_retrying_executor.\
+        task_retries.set(mock_event.task_id, 2)
+    modified_task_id = str(mock_event.task_config.uuid) + '-retry2'
+    modified_task_config = mock_event.task_config.set(
+        'uuid',
+        modified_task_id
+    )
+    modified_mock_event = mock_event.set(
+        'task_config',
+        modified_task_config
+    )
+    modified_mock_event = mock_event.set(
+        'task_id',
+        modified_task_id
+    )
+
+    ret_value = mock_retrying_executor._is_current_attempt(
+        modified_mock_event,
+        original_task_id
+    )
+
+    assert ret_value is True
+
+
+def test_is_not_current_attempt(mock_retrying_executor, mock_event):
+    original_task_id = mock_event.task_id
+    mock_retrying_executor.task_retries = mock_retrying_executor.\
+        task_retries.set(mock_event.task_id, 2)
+    modified_task_id = str(mock_event.task_config.uuid) + '-retry1'
+    modified_task_config = mock_event.task_config.set(
+        'uuid',
+        modified_task_id
+    )
+    modified_mock_event = mock_event.set(
+        'task_config',
+        modified_task_config
+    )
+    modified_mock_event = mock_event.set(
+        'task_id',
+        modified_task_id
+    )
+
+    ret_value = mock_retrying_executor._is_current_attempt(
+        modified_mock_event,
+        original_task_id
+    )
+
+    assert ret_value is False
+
+
+def test_is_unknown_attempt(mock_retrying_executor, mock_event):
+    original_task_id = mock_event.task_id
+    modified_task_id = str(mock_event.task_config.uuid) + '-retry8'
+    modified_task_config = mock_event.task_config.set(
+        'uuid',
+        modified_task_id
+    )
+    modified_mock_event = mock_event.set(
+        'task_config',
+        modified_task_config
+    )
+    modified_mock_event = mock_event.set(
+        'task_id',
+        modified_task_id
+    )
+
+    ret_value = mock_retrying_executor._is_current_attempt(
+        modified_mock_event,
+        original_task_id,
+    )
+
+    assert ret_value is True
+    assert mock_retrying_executor.task_retries.get(original_task_id) == 8

--- a/tests/unit/plugins/mesos/retrying_executor_test.py
+++ b/tests/unit/plugins/mesos/retrying_executor_test.py
@@ -59,9 +59,8 @@ def mock_event(mock_task_config, is_terminal=False):
         raw='raw_event'
     )
 
+
 # task_retry ###################################################################
-
-
 def test_task_retry(mock_retrying_executor, mock_event):
     mock_retrying_executor.task_retries = mock_retrying_executor.\
         task_retries.set(mock_event.task_id, 3)
@@ -84,9 +83,8 @@ def test_task_retry_retries_exhausted(mock_retrying_executor, mock_event):
     assert mock_retrying_executor.run.call_count == 0
     assert not retry_attempted
 
+
 # retry_loop ###################################################################
-
-
 def test_retry_loop_retries_task(mock_retrying_executor, mock_event):
     mock_event = mock_event.set('terminal', True)
     mock_retrying_executor.stopping = True
@@ -95,7 +93,6 @@ def test_retry_loop_retries_task(mock_retrying_executor, mock_event):
         return_value=mock_event)
     mock_retrying_executor.retry = mock.Mock(return_value=True)
     mock_retrying_executor.retry_pred = mock.Mock(return_value=True)
-    mock_retrying_executor.src_queue = Queue()
     mock_retrying_executor.src_queue.put(mock_event)
     mock_retrying_executor.task_retries = mock_retrying_executor.\
         task_retries.set(mock_event.task_id, 1)
@@ -139,14 +136,11 @@ def test_retry_loop_filters_out_non_task(mock_retrying_executor):
     mock_retrying_executor.stopping = True
     mock_retrying_executor._is_current_attempt = mock.Mock(return_value=True)
     mock_retrying_executor.event_with_retries = mock.Mock()
-    mock_retrying_executor.retry = mock.Mock()
-    mock_retrying_executor.src_queue = Queue()
     mock_retrying_executor.src_queue.put(mock_event)
 
     mock_retrying_executor.retry_loop()
 
     assert mock_retrying_executor.dest_queue.qsize() == 1
-    assert mock_retrying_executor.retry.call_count == 0
 
 
 # If retrying_executor receives an event about an attempt for a task the
@@ -162,7 +156,6 @@ def test_retry_loop_recover_attempt(mock_retrying_executor, mock_event):
     mock_retrying_executor.stopping = True
     mock_retrying_executor.retry = mock.Mock(return_value=True)
     mock_retrying_executor.retry_pred = mock.Mock(return_value=True)
-    mock_retrying_executor.src_queue = Queue()
     mock_retrying_executor.src_queue.put(modified_mock_event)
 
     mock_retrying_executor.retry_loop()

--- a/tests/unit/plugins/mesos/timeout_executor_test.py
+++ b/tests/unit/plugins/mesos/timeout_executor_test.py
@@ -74,15 +74,12 @@ def test_timeout_loop_nontask(
     mock_event = mock_event.set('kind', 'control')
     mock_entry = TaskEntry('different_id', deadline=1234)
     mock_timeout_executor.stopping = True
-    mock_timeout_executor.src_queue = Queue()
     mock_timeout_executor.src_queue.put(mock_event)
     mock_timeout_executor.running_tasks.append(mock_entry)
-    mock_timeout_executor.downstream_executor.kill = mock.Mock()
     time.time = mock.Mock(return_value=0)
 
     mock_timeout_executor.timeout_loop()
 
-    assert mock_timeout_executor.downstream_executor.kill.call_count == 0
     assert len(mock_timeout_executor.running_tasks) == 1
 
 
@@ -92,7 +89,6 @@ def test_timeout_loop_terminal_task_timed_out(
     mock_entry,
 ):
     mock_timeout_executor.stopping = True
-    mock_timeout_executor.src_queue = Queue()
     mock_timeout_executor.src_queue.put(mock_event)
     mock_timeout_executor.running_tasks.append(mock_entry)
     mock_timeout_executor.killed_tasks.append(mock_entry.task_id)
@@ -112,7 +108,6 @@ def test_timeout_loop_existing_nonterminal_task(
 ):
     mock_event = mock_event.set('terminal', False)
     mock_timeout_executor.stopping = True
-    mock_timeout_executor.src_queue = Queue()
     mock_timeout_executor.src_queue.put(mock_event)
     mock_timeout_executor.running_tasks.append(mock_entry)
     mock_timeout_executor.downstream_executor.kill = mock.Mock()
@@ -133,7 +128,6 @@ def test_timeout_loop_nonexistent_nonterminal_task(
 ):
     mock_event = mock_event.set('terminal', False)
     mock_timeout_executor.stopping = True
-    mock_timeout_executor.src_queue = Queue()
     mock_timeout_executor.src_queue.put(mock_event)
     mock_timeout_executor.downstream_executor.kill = mock.Mock()
     time.time = mock.Mock(return_value=10000)

--- a/tests/unit/plugins/mesos/timeout_executor_test.py
+++ b/tests/unit/plugins/mesos/timeout_executor_test.py
@@ -1,6 +1,10 @@
+import time
+from queue import Queue
+
 import mock
 import pytest
 
+from task_processing.interfaces.event import Event
 from task_processing.plugins.mesos.task_config import MesosTaskConfig
 from task_processing.plugins.mesos.timeout_executor import TaskEntry
 from task_processing.plugins.mesos.timeout_executor import TimeoutExecutor
@@ -13,8 +17,15 @@ def mock_Thread():
 
 
 @pytest.fixture
-def mock_downstream():
-    return mock.MagicMock()
+def source_queue():
+    return Queue()
+
+
+@pytest.fixture
+def mock_downstream(source_queue):
+    executor = mock.MagicMock()
+    executor.get_event_queue.return_value = source_queue
+    return executor
 
 
 @pytest.fixture
@@ -22,6 +33,120 @@ def mock_timeout_executor(mock_Thread, mock_downstream):
     return TimeoutExecutor(downstream_executor=mock_downstream)
 
 
+@pytest.fixture
+def mock_task_config():
+    return MesosTaskConfig(
+        uuid='mock_uuid',
+        name='mock_name',
+        image='mock_image',
+        cmd='mock_cmd',
+        timeout=1000,
+    )
+
+
+@pytest.fixture
+def mock_entry(mock_task_config):
+    return TaskEntry(
+        task_id=mock_task_config.task_id,
+        deadline=mock_task_config.timeout + 2000,
+    )
+
+
+@pytest.fixture
+def mock_event(mock_task_config):
+    return Event(
+        kind='task',
+        timestamp=1234.5678,
+        terminal=True,
+        task_id=mock_task_config.task_id,
+        platform_type='mesos',
+        message='mock_message',
+        task_config=mock_task_config,
+        raw='raw_event',
+    )
+
+
+# timeout_loop #################################################################
+def test_timeout_loop_nontask(
+    mock_timeout_executor,
+    mock_event,
+):
+    mock_event = mock_event.set('kind', 'control')
+    mock_entry = TaskEntry('different_id', deadline=1234)
+    mock_timeout_executor.stopping = True
+    mock_timeout_executor.src_queue = Queue()
+    mock_timeout_executor.src_queue.put(mock_event)
+    mock_timeout_executor.running_tasks.append(mock_entry)
+    mock_timeout_executor.downstream_executor.kill = mock.Mock()
+    time.time = mock.Mock(return_value=0)
+
+    mock_timeout_executor.timeout_loop()
+
+    assert mock_timeout_executor.downstream_executor.kill.call_count == 0
+    assert len(mock_timeout_executor.running_tasks) == 1
+
+
+def test_timeout_loop_terminal_task_timed_out(
+    mock_timeout_executor,
+    mock_event,
+    mock_entry,
+):
+    mock_timeout_executor.stopping = True
+    mock_timeout_executor.src_queue = Queue()
+    mock_timeout_executor.src_queue.put(mock_event)
+    mock_timeout_executor.running_tasks.append(mock_entry)
+    mock_timeout_executor.killed_tasks.append(mock_entry.task_id)
+    mock_timeout_executor.downstream_executor.kill = mock.Mock()
+
+    mock_timeout_executor.timeout_loop()
+
+    assert mock_timeout_executor.downstream_executor.kill.call_count == 0
+    assert len(mock_timeout_executor.running_tasks) == 0
+    assert len(mock_timeout_executor.killed_tasks) == 0
+
+
+def test_timeout_loop_existing_nonterminal_task(
+    mock_timeout_executor,
+    mock_event,
+    mock_entry,
+):
+    mock_event = mock_event.set('terminal', False)
+    mock_timeout_executor.stopping = True
+    mock_timeout_executor.src_queue = Queue()
+    mock_timeout_executor.src_queue.put(mock_event)
+    mock_timeout_executor.running_tasks.append(mock_entry)
+    mock_timeout_executor.downstream_executor.kill = mock.Mock()
+    time.time = mock.Mock(return_value=10000)
+
+    mock_timeout_executor.timeout_loop()
+
+    assert mock_timeout_executor.downstream_executor.kill.call_args ==\
+        mock.call(mock_entry.task_id)
+    assert len(mock_timeout_executor.running_tasks) == 0
+    assert len(mock_timeout_executor.killed_tasks) == 1
+
+
+def test_timeout_loop_nonexistent_nonterminal_task(
+    mock_timeout_executor,
+    mock_event,
+    mock_entry,
+):
+    mock_event = mock_event.set('terminal', False)
+    mock_timeout_executor.stopping = True
+    mock_timeout_executor.src_queue = Queue()
+    mock_timeout_executor.src_queue.put(mock_event)
+    mock_timeout_executor.downstream_executor.kill = mock.Mock()
+    time.time = mock.Mock(return_value=10000)
+
+    mock_timeout_executor.timeout_loop()
+
+    assert mock_timeout_executor.downstream_executor.kill.call_args ==\
+        mock.call(mock_entry.task_id)
+    assert len(mock_timeout_executor.running_tasks) == 0
+    assert len(mock_timeout_executor.killed_tasks) == 1
+
+
+# run ##########################################################################
 def test_run(mock_timeout_executor, mock_downstream):
     mock_config = MesosTaskConfig(image='fake', cmd='cat', timeout=60)
     mock_timeout_executor.run(mock_config)
@@ -30,19 +155,55 @@ def test_run(mock_timeout_executor, mock_downstream):
     assert len(mock_timeout_executor.running_tasks) == 1
 
 
-def test_kill_existing_task(mock_timeout_executor, mock_downstream):
-    mock_timeout_executor.running_tasks = [TaskEntry("task", 10)]
-    result = mock_timeout_executor.kill("task")
-    assert result == mock_downstream.kill.return_value
-    assert mock_downstream.kill.call_args == mock.call("task")
-
-
+# reconcile ####################################################################
 def test_reconcile(mock_timeout_executor, mock_downstream):
     mock_timeout_executor.reconcile("task")
     assert mock_downstream.reconcile.call_args == mock.call("task")
 
 
+# kill #########################################################################
+def test_kill_existing_task(mock_timeout_executor, mock_downstream):
+    mock_timeout_executor.running_tasks = [TaskEntry("task", 10)]
+    mock_timeout_executor.downstream_executor.kill = mock.Mock(
+        return_value=True)
+
+    result = mock_timeout_executor.kill("task")
+
+    assert result == mock_downstream.kill.return_value
+    assert mock_downstream.kill.call_args == mock.call("task")
+    assert len(mock_timeout_executor.running_tasks) == 0
+    assert len(mock_timeout_executor.killed_tasks) == 1
+
+
+# stop #########################################################################
 def test_stop(mock_timeout_executor, mock_downstream):
     mock_timeout_executor.stop()
     assert mock_downstream.stop.call_args == mock.call()
     assert mock_timeout_executor.stopping
+
+
+# _insert_new_running_task_entry ###############################################
+def test_insert_new_running_task_entry_enumerate(mock_timeout_executor):
+    mock_entry_one = TaskEntry('fake_entry_one', 1)
+    mock_entry_two = TaskEntry('fake_entry_two', 2)
+    mock_entry_three = TaskEntry('fake_entry_three', 3)
+    mock_timeout_executor.running_tasks.append(mock_entry_one)
+    mock_timeout_executor.running_tasks.append(mock_entry_three)
+
+    mock_timeout_executor._insert_new_running_task_entry(mock_entry_two)
+
+    assert [entry.deadline for entry in mock_timeout_executor.running_tasks] ==\
+        [1, 2, 3]
+
+
+def test_insert_new_running_task_entry_append(mock_timeout_executor):
+    mock_entry_one = TaskEntry('fake_entry_one', 1)
+    mock_entry_two = TaskEntry('fake_entry_two', 2)
+    mock_entry_three = TaskEntry('fake_entry_three', 3)
+    mock_timeout_executor.running_tasks.append(mock_entry_one)
+    mock_timeout_executor.running_tasks.append(mock_entry_two)
+
+    mock_timeout_executor._insert_new_running_task_entry(mock_entry_three)
+
+    assert [entry.deadline for entry in mock_timeout_executor.running_tasks] ==\
+        [1, 2, 3]


### PR DESCRIPTION
### Description
- Update timeout and retrying executors to allow missing tasks to reregister during reconciliation
- For the timeout executor, if it now encounters a non-terminal task update that the executor doesn't know about, it will add the task to its list of running_tasks using the update's timestamp as a baseline from which to establish a timeout deadline.
- For the retrying executor, if it now encounters a task update that the executor doesn't know about, it will similarly add the task to its list of task_retries and assumes the update's attempt number is the number of attempts so far.
- The above 2 points are a consequence of needing to pull information that is lost unless we can somehow recover task histories (like when a task started).

### Testing done
- make test