### PR TITLE
deal with missing task metadata more gracefully

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -342,7 +342,13 @@ class ExecutionFramework(Scheduler):
         current_task_state = 'UNKNOWN' if task_launch_failed else 'TASK_STAGING'
 
         for task in tasks_to_launch:
-            md = self.task_metadata[task.task_id]
+            md = self.task_metadata.get(task.task_id)
+            if not md:
+                log.warning(
+                    f'trying to launch task {task.task_id}, but it is not in task metadata.'
+                    'current keys in task_metadata: {self.task_metadata.keys()}'
+                )
+                continue
             self.task_metadata = self.task_metadata.set(
                 task.task_id,
                 md.set(

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -612,6 +612,15 @@ def test_background_thread_removes_offer_timeout(
     assert event.task_id == task_id
 
 
+def test_launch_tasks_for_offer_task_missing(
+    ef,
+    fake_task,
+    fake_offer
+):
+    tasks_to_launch = [fake_task]
+    ef.launch_tasks_for_offer(fake_offer, tasks_to_launch)
+
+
 def test_reconcile_task_unknown(
     ef,
     mock_driver,


### PR DESCRIPTION
this deals with a condition where a task has no entry in the task
metadata map. we don't want to crash the main thread in response, so we
just log