### PR TITLE
Split execution framework background check

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -231,7 +231,9 @@ class ExecutionFramework(Scheduler):
                 [Dict({'task_id': Dict({'value': task_id})}) for
                     task_id in tasks_to_reconcile]
             )
-            log.info(f'background check done in {time.time() - time_now}s')
+            elapsed = time.time() - time_now
+            log.info(f'background check done in {elapsed}s')
+            get_metric(metrics.BGCHECK_TIME_TIMER).record(elapsed)
             time.sleep(10)
 
     def reconcile_task(self, task_config):

--- a/task_processing/plugins/mesos/metrics.py
+++ b/task_processing/plugins/mesos/metrics.py
@@ -16,3 +16,5 @@ TASK_STUCK_COUNT = 'taskproc.mesos.task_stuck_count'
 
 OFFER_DELAY_TIMER = 'taskproc.mesos.offer_delay'
 BLACKLISTED_AGENTS_COUNT = 'taskproc.mesos.blacklisted_agents_count'
+
+BGCHECK_TIME_TIMER = 'taskproc.mesos.bgcheck_time'

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -79,8 +79,11 @@ def test_ef_kills_stuck_tasks(
         agent_id='fake_agent_id',
         timeout=900
     )
-    assert mock_get_metric.call_count == 1
-    assert mock_get_metric.call_args == mock.call(metrics.TASK_STUCK_COUNT)
+    assert mock_get_metric.call_count == 2
+    assert mock_get_metric.call_args_list == [
+        mock.call(metrics.TASK_STUCK_COUNT),
+        mock.call(metrics.BGCHECK_TIME_TIMER),
+    ]
     assert mock_get_metric.return_value.count.call_count == 1
     assert mock_get_metric.return_value.count.call_args == mock.call(1)
 
@@ -110,9 +113,11 @@ def test_reenqueue_tasks_stuck_in_unknown_state(
     assert ef.enqueue_task.call_args == mock.call(
         ef.task_metadata[task_id].task_config
     )
-    assert mock_get_metric.call_count == 1
-    assert mock_get_metric.call_args == mock.call(
-        metrics.TASK_FAILED_TO_LAUNCH_COUNT)
+    assert mock_get_metric.call_count == 2
+    assert mock_get_metric.call_args_list == [
+        mock.call(metrics.TASK_FAILED_TO_LAUNCH_COUNT),
+        mock.call(metrics.BGCHECK_TIME_TIMER),
+    ]
     assert mock_get_metric.return_value.count.call_count == 1
     assert mock_get_metric.return_value.count.call_args == mock.call(1)
 


### PR DESCRIPTION
- move per-task logic out of `_background_check` into `_background_check_task`
- log timing information for each bg check run