### PR TITLE
Fix incorrect log message when offer is declined and missing metric in execution framework

### DIFF
--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -292,7 +292,8 @@ def test_initialize_metrics(ef):
 
         timers = [
             metrics.TASK_QUEUED_TIME_TIMER,
-            metrics.OFFER_DELAY_TIMER
+            metrics.OFFER_DELAY_TIMER,
+            metrics.BGCHECK_TIME_TIMER,
         ]
         assert mock_create_timer.call_count == len(timers)
         for tmr in timers:


### PR DESCRIPTION
- no `continue` near :616 would result in both declined and accepted log messages
- create missing timer metric (line 434)
- change formatting to f-strings (the rest)