### PR TITLE
now require min version of pymesos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     extras_require={
         # We can add the Mesos specific dependencies here
-        'mesos_executor': ['addict', 'pymesos', 'requests'],
+        'mesos_executor': ['addict', 'pymesos>=0.2.14', 'requests'],
         'metrics': ['yelp-meteorite'],
         'persistence': ['boto3'],
     }


### PR DESCRIPTION
The failover stuff (startign in taskproc 0.0.17) is only in pymesos 0.2.14 and up.