### PR TITLE
Only get_metric for insufficient offer once

### DIFF
--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -572,7 +572,7 @@ class ExecutionFramework(Scheduler):
 
                 for task in tasks_to_defer:
                     self.task_queue.put(task)
-                    get_metric(metrics.TASK_INSUFFICIENT_OFFER_COUNT).count(1)
+                get_metric(metrics.TASK_INSUFFICIENT_OFFER_COUNT).count(len(tasks_to_defer))
 
                 if len(tasks_to_launch) == 0:
                     declined['bad resources'].append(offer.id.value)

--- a/tests/unit/plugins/mesos/execution_framework_test.py
+++ b/tests/unit/plugins/mesos/execution_framework_test.py
@@ -394,7 +394,7 @@ def test_resource_offers_launch_tasks_failed(
     assert not ef.are_offers_suppressed
     assert mock_driver.declineOffer.call_count == 1
     assert mock_driver.launchTasks.call_count == 1
-    assert mock_get_metric.call_count == 2
+    assert mock_get_metric.call_count == 3
     assert ef.task_metadata[task_id].task_state == 'UNKNOWN'
 
 


### PR DESCRIPTION
tzhu made this suggestion, apparently it improves jolt cpu usage by 10%:
```
status quo: 32:32min CPU in 48min (0.677 cpu)
optimized: 8:00~8:15min CPU in 15min (0.541 cpu)
```
I checked the other places we call get_metric, nothing else obvious to optimize.