### PR TITLE
Stop dynamodb persister from persisting control events

### DIFF
--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -1,10 +1,11 @@
 import json
 import uuid
+from typing import Any
 
 from pyrsistent import field
 from pyrsistent import freeze
 from pyrsistent import m
-from pyrsistent import PMap
+from pyrsistent import PMap  # type: ignore
 from pyrsistent import pmap
 from pyrsistent import PRecord
 
@@ -31,7 +32,7 @@ class Event(PRecord):
     # use time.time() to generate
     timestamp = field(type=float, initial=0.0)
     # reference to platform-specific event object
-    raw = field(mandatory=True, initial=None)
+    raw: Any = field(mandatory=True, initial=None)
     # free-form dictionary for stack-specific data
     extensions = field(type=PMap, initial=m(), factory=pmap)
     # is this the last event for a task?

--- a/task_processing/interfaces/task_executor.py
+++ b/task_processing/interfaces/task_executor.py
@@ -6,7 +6,7 @@ from pyrsistent import PRecord
 
 
 class DefaultTaskConfigInterface(PRecord):
-    task_id = field(type=uuid.UUID, initial=uuid.uuid4)
+    uuid = field(type=uuid.UUID, initial=uuid.uuid4)
     name = field(type=str, initial='default')
 
 

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -11,9 +11,10 @@ from addict import Dict
 from pymesos.interface import Scheduler
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap
+from pyrsistent import PMap  # type: ignore
 from pyrsistent import pmap
 from pyrsistent import PRecord
+from pyrsistent import PVector  # type: ignore
 from pyrsistent import v
 
 from task_processing.interfaces.event import control_event
@@ -89,8 +90,8 @@ class ExecutionFramework(Scheduler):
 
         self.offer_decline_filter = Dict(refuse_seconds=self.offer_backoff)
         self._lock = threading.RLock()
-        self.blacklisted_slaves = v()
-        self.task_metadata = m()
+        self.blacklisted_slaves: PVector = v()
+        self.task_metadata: PMap = m()
 
         self._initialize_metrics()
         self._last_offer_time: Optional[float] = None

--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import requests
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap
+from pyrsistent import PMap  # type: ignore
 from pyrsistent import pmap
 from pyrsistent import PRecord
 from pyrsistent import v

--- a/task_processing/plugins/mesos/resource_helpers.py
+++ b/task_processing/plugins/mesos/resource_helpers.py
@@ -5,7 +5,7 @@ from pyrsistent import field
 from pyrsistent import m
 from pyrsistent import pmap
 from pyrsistent import PRecord
-from pyrsistent import PVector
+from pyrsistent import PVector  # type: ignore
 from pyrsistent import pvector
 from pyrsistent import v
 

--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -2,13 +2,13 @@ import uuid
 
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap
+from pyrsistent import PMap  # type: ignore
 from pyrsistent import pmap
-from pyrsistent import PRecord
-from pyrsistent import PVector
+from pyrsistent import PVector  # type: ignore
 from pyrsistent import pvector
 from pyrsistent import v
 
+from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
 from task_processing.plugins.mesos.constraints import Constraint
 from task_processing.plugins.mesos.constraints import \
     valid_constraint_operator_name
@@ -42,7 +42,7 @@ def _valid_constraints(constraints):
         return (True, None)
 
 
-class MesosTaskConfig(PRecord):
+class MesosTaskConfig(DefaultTaskConfigInterface):
     def __invariant__(conf):
         return (
             (

--- a/task_processing/plugins/persistence/dynamodb_persistence.py
+++ b/task_processing/plugins/persistence/dynamodb_persistence.py
@@ -28,6 +28,8 @@ class DynamoDBPersister(Persister):
         return [self.item_to_event(item) for item in res['Items']]
 
     def write(self, event):
+        if event.kind == 'control':
+            return None
         return self.ddb_client.put_item(
             TableName=self.table_name,
             Item=self._event_to_item(event)['M']

--- a/task_processing/task_processor.py
+++ b/task_processing/task_processor.py
@@ -3,7 +3,7 @@ import logging
 
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap
+from pyrsistent import PMap  # type: ignore
 from pyrsistent import pmap
 from pyrsistent import PRecord
 

--- a/tests/unit/plugins/persistence/dynamo_persistence_test.py
+++ b/tests/unit/plugins/persistence/dynamo_persistence_test.py
@@ -77,7 +77,6 @@ events = st.builds(
 @given(x=events)
 def test_event_to_item_timestamp(x, persister):
     res = persister._event_to_item(x)['M']
-    print(res)
     assert 'N' in res['timestamp'].keys()
     assert 'BOOL' in res['success'].keys()
     assert 'BOOL' in res['terminal'].keys()


### PR DESCRIPTION
### Description
- Currently, the DynamoDB persister persists both task and control events. The problem is that control events do not `task_id`s, but our DynamoDB tables expect them.
- In this change, I made it so that we do not persist control events, only task events.

### Testing
- manual testing on a dev paasta master
- make test

### Notes to reviewers
- Error when persisting control events: https://gist.github.com/kawaiwanyelp/886819f047a1785e3e823a8771100ff6
- This change also includes a bunch of changes to silence or fix mypy errors. 
    - pyrsistent seems to be bugged in that `PMap`s and `PVector`s do not seem to play well with mypy. Hence, I've instructed `mypy` to ignore them using `# type: ignore`