### PR TITLE
Remove mypy type ignores fix other type annotations for pyrsistent

### DIFF
--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -5,7 +5,7 @@ from typing import Any
 from pyrsistent import field
 from pyrsistent import freeze
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
 

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -11,10 +11,10 @@ from addict import Dict
 from pymesos.interface import Scheduler
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
-from pyrsistent import PVector  # type: ignore
+from pyrsistent import PVector
 from pyrsistent import v
 
 from task_processing.interfaces.event import control_event

--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import requests
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
 from pyrsistent import v

--- a/task_processing/plugins/mesos/resource_helpers.py
+++ b/task_processing/plugins/mesos/resource_helpers.py
@@ -5,7 +5,7 @@ from pyrsistent import field
 from pyrsistent import m
 from pyrsistent import pmap
 from pyrsistent import PRecord
-from pyrsistent import PVector  # type: ignore
+from pyrsistent import PVector
 from pyrsistent import pvector
 from pyrsistent import v
 
@@ -25,7 +25,7 @@ class ResourceSet(PRecord):
     mem = NUMERIC_RESOURCE
     disk = NUMERIC_RESOURCE
     gpus = NUMERIC_RESOURCE
-    ports = field(type=PVector, initial=v(), factory=pvector)
+    ports: PVector = field(type=PVector, initial=v(), factory=pvector)
 
 
 def get_offer_resources(offer: addict.Dict, role: str) -> ResourceSet:

--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -2,9 +2,9 @@ import uuid
 
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
-from pyrsistent import PVector  # type: ignore
+from pyrsistent import PVector
 from pyrsistent import pvector
 from pyrsistent import v
 
@@ -92,7 +92,7 @@ class MesosTaskConfig(DefaultTaskConfigInterface):
                     initial=v(),
                     factory=pvector,
                     invariant=valid_volumes)
-    ports = field(type=PVector, initial=v(), factory=pvector)
+    ports: PVector = field(type=PVector, initial=v(), factory=pvector)
     cap_add = field(type=PVector, initial=v(), factory=pvector)
     ulimit = field(type=PVector, initial=v(), factory=pvector)
     uris = field(type=PVector, initial=v(), factory=pvector)
@@ -110,11 +110,17 @@ class MesosTaskConfig(DefaultTaskConfigInterface):
         factory=float,
         invariant=lambda t: (t > 0, 'timeout > 0')
     )
+
+    def constraint_factory(c) -> PVector:
+        return pvector((Constraint(
+            attribute=v[0],
+            operator=v[1],
+            value=v[2],
+        ) for v in c))
     constraints = field(
         type=PVector,
         initial=v(),
-        factory=lambda c: pvector((Constraint(attribute=v[0], operator=v[1],
-                                              value=v[2]) for v in c)),
+        factory=constraint_factory,
         invariant=_valid_constraints,
     )
     use_cached_image = field(type=bool, initial=True, factory=bool)

--- a/task_processing/task_processor.py
+++ b/task_processing/task_processor.py
@@ -3,7 +3,7 @@ import logging
 
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
 


### PR DESCRIPTION
### Description
- In a previous update, I instructed `mypy` to ignore some `pyrsistent` types. It turns out, `pyrsistent`, at the time, had some `mypy` bugs, which have since been fixed.
- I've removed the ignores and added some last type annotations.

### Testing
- make test
- mypy task_processing