### PR TITLE
Remove type ignores since pyrsistent now has passable type annotations

### DIFF
--- a/task_processing/interfaces/event.py
+++ b/task_processing/interfaces/event.py
@@ -5,7 +5,7 @@ from typing import Any
 from pyrsistent import field
 from pyrsistent import freeze
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
 

--- a/task_processing/plugins/mesos/execution_framework.py
+++ b/task_processing/plugins/mesos/execution_framework.py
@@ -11,10 +11,10 @@ from addict import Dict
 from pymesos.interface import Scheduler
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
-from pyrsistent import PVector  # type: ignore
+from pyrsistent import PVector
 from pyrsistent import v
 
 from task_processing.interfaces.event import control_event

--- a/task_processing/plugins/mesos/logging_executor.py
+++ b/task_processing/plugins/mesos/logging_executor.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import requests
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
 from pyrsistent import v
@@ -36,7 +36,7 @@ class LogMetadata(PRecord):
 
 
 def standard_handler(task_id, message, stream):
-    print(message, file=sys.stderr if stream is 'stderr' else sys.stdout)
+    print(message, file=sys.stderr if stream == 'stderr' else sys.stdout)
 
 
 class MesosLoggingExecutor(TaskExecutor):

--- a/task_processing/plugins/mesos/resource_helpers.py
+++ b/task_processing/plugins/mesos/resource_helpers.py
@@ -1,11 +1,13 @@
 from typing import Tuple
+from typing import TYPE_CHECKING
 
 import addict
 from pyrsistent import field
 from pyrsistent import m
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
-from pyrsistent import PVector  # type: ignore
+from pyrsistent import PVector
 from pyrsistent import pvector
 from pyrsistent import v
 
@@ -25,7 +27,9 @@ class ResourceSet(PRecord):
     mem = NUMERIC_RESOURCE
     disk = NUMERIC_RESOURCE
     gpus = NUMERIC_RESOURCE
-    ports = field(type=PVector, initial=v(), factory=pvector)
+    ports = field(type=(PVector[PMap] if TYPE_CHECKING else PVector),
+                  initial=v(),
+                  factory=pvector)
 
 
 def get_offer_resources(offer: addict.Dict, role: str) -> ResourceSet:
@@ -65,8 +69,8 @@ def allocate_task_resources(
             continue
         offer_resources = offer_resources.set(res, val - task_config[res])
 
-    port = offer_resources.ports[0].begin
-    if offer_resources.ports[0].begin == offer_resources.ports[0].end:
+    port = offer_resources.ports[0]['begin']
+    if offer_resources.ports[0]['begin'] == offer_resources.ports[0]['end']:
         avail_ports = offer_resources.ports[1:]
     else:
         new_port_range = offer_resources.ports[0].set('begin', port + 1)

--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -1,10 +1,12 @@
 import uuid
+from typing import Sequence
+from typing import TYPE_CHECKING
 
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
-from pyrsistent import PVector  # type: ignore
+from pyrsistent import PVector
 from pyrsistent import pvector
 from pyrsistent import v
 
@@ -92,7 +94,9 @@ class MesosTaskConfig(DefaultTaskConfigInterface):
                     initial=v(),
                     factory=pvector,
                     invariant=valid_volumes)
-    ports = field(type=PVector, initial=v(), factory=pvector)
+    ports = field(type=(PVector[PMap] if TYPE_CHECKING else PVector),
+                  initial=v(),
+                  factory=pvector)
     cap_add = field(type=PVector, initial=v(), factory=pvector)
     ulimit = field(type=PVector, initial=v(), factory=pvector)
     uris = field(type=PVector, initial=v(), factory=pvector)
@@ -111,7 +115,7 @@ class MesosTaskConfig(DefaultTaskConfigInterface):
         invariant=lambda t: (t > 0, 'timeout > 0')
     )
     constraints = field(
-        type=PVector,
+        type=(Sequence[Constraint] if TYPE_CHECKING else PVector),
         initial=v(),
         factory=lambda c: pvector((Constraint(attribute=v[0], operator=v[1],
                                               value=v[2]) for v in c)),

--- a/task_processing/plugins/mesos/translator.py
+++ b/task_processing/plugins/mesos/translator.py
@@ -17,7 +17,7 @@ def make_mesos_container_info(task_config: MesosTaskConfig) -> addict.Dict:
         volumes=thaw(task_config.volumes),
     )
     port_mappings = [addict.Dict(
-        host_port=task_config.ports[0].begin, container_port=8888)]
+        host_port=task_config.ports[0]['begin'], container_port=8888)]
     if container_info.type == 'DOCKER':
         container_info.docker = addict.Dict(
             image=task_config.image,

--- a/task_processing/task_processor.py
+++ b/task_processing/task_processor.py
@@ -3,7 +3,7 @@ import logging
 
 from pyrsistent import field
 from pyrsistent import m
-from pyrsistent import PMap  # type: ignore
+from pyrsistent import PMap
 from pyrsistent import pmap
 from pyrsistent import PRecord
 

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,3 +1,5 @@
+from queue import Queue
+
 from task_processing.interfaces.task_executor import TaskExecutor
 
 
@@ -8,6 +10,15 @@ def test_task_executor():
 
         def kill(self, task_id):
             return True
+
+        def get_event_queue(self):
+            return Queue()
+
+        def reconcile(self, task_config):
+            pass
+
+        def stop(self):
+            pass
 
     t = TaskExecutorImpl()
     assert t.run('foo') == 'foo'

--- a/tests/unit/interfaces/event_test.py
+++ b/tests/unit/interfaces/event_test.py
@@ -54,4 +54,4 @@ def test_event_optional_attributes(event):
     assert event.message is None
     assert event.terminal is False
     assert event.timestamp == 0.0
-    assert event.task_id is "123"
+    assert event.task_id == "123"


### PR DESCRIPTION
### Description
- I previously added "type: ignore"s since pyrsistent didn't have good type annotations. Now that they have, I have removed them and put in type annotations for task_processing.
- I use TYPE_CHECKING because not using it in the way I do causes tests to fail even if mypy checks pass.

### Testing
make test

### Notes to reviewers
- In #135, @vkhromov advocated for strict type annotations. However, I had a lot of trouble doing so for Mesos things like Offers that we use via duck typing. Mesos does not provide type annotated interfaces we can use to type them, so I'd have to use `Any`. I think removing the ignores for now is sufficient. If anyone wants REALLY strict type annotations, please comment.