### PR TITLE
Restart driver if it exits for any reason

### DIFF
--- a/tests/unit/plugins/mesos/mesos_executor_test.py
+++ b/tests/unit/plugins/mesos/mesos_executor_test.py
@@ -55,7 +55,7 @@ def test_creates_execution_framework_and_driver(
     )
 
     assert mock_Thread.call_args == mock.call(
-        target=mesos_executor.driver.run,
+        target=mesos_executor._run_driver,
         args=()
     )
 


### PR DESCRIPTION
The driver exits on things like HTTP error codes or parsing errors. I think it makes sense to reconnect in these cases, instead of letting the execution framework continue when the driver thread has stopped.

example of the driver exiting: https://github.com/douban/pymesos/blob/master/pymesos/process.py#L162