### PR TITLE
Pin mypy to get a stable build

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ docker-compose
 flake8
 hypothesis
 mock
-mypy
+mypy==0.560
 pre-commit
 pytest
 pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+skipsdist=True
 envlist = py36
 indexserver =
     default = https://pypi.python.org/simple


### PR DESCRIPTION
I love running the latest versions of everything as much as the next person, but the latest version of mypy is much more strict and understanding than our codebase currently allows.

I would like to start by pinning first to get the build green, then improving our annotations and upgrading mypy in a different PR.