### PR TITLE
Make the LIKE constraint a "full match"

### DIFF
--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -q && \
         openssh-server docker.io curl vim jq libsvn-dev \
     && apt-get clean
 
-RUN add-apt-repository ppa:jonathonf/python-3.6
+RUN add-apt-repository ppa:deadsnakes
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.6 python3.6-dev python3.6-venv
 RUN wget https://bootstrap.pypa.io/get-pip.py

--- a/task_processing/plugins/mesos/constraints.py
+++ b/task_processing/plugins/mesos/constraints.py
@@ -13,7 +13,7 @@ def notequals_op(expected_value, actual_value):
 
 
 def like_op(re_pattern, actual_value):
-    return re.match(re_pattern, actual_value)
+    return re.fullmatch(re_pattern, actual_value)
 
 
 def unlike_op(re_pattern, actual_value):

--- a/tests/unit/plugins/mesos/constraints_test.py
+++ b/tests/unit/plugins/mesos/constraints_test.py
@@ -192,6 +192,16 @@ def test_constraints_LIKE_not_match(fake_dict):
             ),
         ],
     )
+    assert not attributes_match_constraints(
+        fake_dict,
+        [
+            Constraint(
+                attribute='region',
+                operator='LIKE',
+                value='fake_region'
+            )
+        ]
+    )
 
 
 def test_constraints_UNLIKE_match(fake_dict):

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
     pip install -e .[mesos_executor,persistence]
     - pip install yelp-meteorite
     mypy task_processing
-    pytest --cov=task_processing --cov-fail-under=75 -v {posargs:tests}/unit
+    pytest {posargs:tests}/unit
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 


### PR DESCRIPTION
(COMPINFRA-333) We have a "stable" pool and a "stable_batch" pool, and
jobs that are supposed to run on the "stable" pool are getting scheduled
on the "stable_batch" pool because the constraint is too open. This
change should make it so that stuff only gets scheduled on the pool they
specify.

(deleted coverage because it's broken in Python 3.6.0)