### PR TITLE
Enable GH Actions for all PRs + upload to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,14 @@
 name: CI
 
 # Controls when the action will run.
-on: [push, release]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  release:
 jobs:
   tox:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   release:
 jobs:
   tox:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,41 @@
+---
+name: Upload to PyPI
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  tox:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        make_target: [test, tox_integration, tox_docs]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      # GHA won't setup tox for us and we use tox-pip-extensions for venv-update
+      - run: pip install tox==3.2 tox-pip-extensions==1.3.0
+      - run: make ${{ matrix.make_target }}
+  pypi:
+    # lets run tests before we push anything to pypi, much like we do internally
+    needs: tox
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      # GHA won't setup tox for us and we use tox-pip-extensions for venv-update
+      # and we need wheel for actually building wheels :p
+      - run: pip install tox==3.2 tox-pip-extensions==1.3.0 wheel
+      # this will create an sdist and wheel under dist/
+      - run: make pypi
+      # and then this uploads those artifacts to pypi
+      - uses: pypa/gh-action-pypi-publish@v1.2.2
+        with:
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Our previous config made it so that only PRs made from a branch on this
repo would get tested - so anyone creating a PR from their fork would
not get their changes tested automatically.

Additionally, add back in the config to upload to PyPI since Tron will 
need to pick up these builds for GH Actions.