### PR TITLE
Add a KubeClient class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setup(
         'mesos_executor': ['addict', 'pymesos>=0.2.14', 'requests'],
         'metrics': ['yelp-meteorite'],
         'persistence': ['boto3'],
+        'k8s': ['kubernetes']
     }
 )

--- a/task_processing/plugins/kubernetes/kube_client.py
+++ b/task_processing/plugins/kubernetes/kube_client.py
@@ -1,0 +1,25 @@
+import os
+from typing import Optional
+
+from kubernetes import client as kube_client
+from kubernetes import config as kube_config
+
+
+class KubeClient:
+    def __init__(self, kube_config_path: Optional[str] = None) -> None:
+        kube_config_path = kube_config_path or os.environ.get("KUBECONFIG")
+        if kube_config_path is None:
+            raise ValueError(
+                "No kubeconfig specified: set a KUBECONFIG environment variable "
+                "or pass a value for `kube_config_path`!"
+            )
+
+        kube_config.load_kube_config(
+            config_file=kube_config_path,
+            context=os.environ.get("KUBECONTEXT")
+        )
+
+        # any Kubernetes APIs that we use should be added as members here (much like as we
+        # do in the KubeClient class in PaaSTA) to ensure that they're only used after we've
+        # loaded the relevant kubeconfig
+        self.core = kube_client.CoreV1Api()

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -1,9 +1,13 @@
 from task_processing.interfaces import TaskExecutor
+from task_processing.plugins.kubernetes.kube_client import KubeClient
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 
 
 class KubernetesPodExecutor(TaskExecutor):
     TASK_CONFIG_INTERFACE = KubernetesTaskConfig
+
+    def __init__(self):
+        self.kube_client = KubeClient()
 
     def run(self, task_config):
         pass

--- a/tests/unit/plugins/kubernetes/kube_client_test.py
+++ b/tests/unit/plugins/kubernetes/kube_client_test.py
@@ -1,0 +1,59 @@
+import os
+from unittest import mock
+
+import pytest
+
+from task_processing.plugins.kubernetes.kube_client import KubeClient
+
+
+def test_KubeClient_no_kubeconfig():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ), pytest.raises(ValueError):
+        KubeClient()
+
+
+def test_KubeClient_kubeconfig_init():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client:
+        client = KubeClient(kube_config_path="/some/kube/config.conf")
+
+        assert client.core == mock_kube_client.CoreV1Api()
+
+
+def test_KubeClient_kubeconfig_env_var():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client, mock.patch.dict(os.environ, {"KUBECONFIG": "/another/kube/config.conf"}):
+        client = KubeClient()
+
+        assert client.core == mock_kube_client.CoreV1Api()
+
+
+def test_KubeClient_kubeconfig_init_overrides_env_var():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ) as mock_load_config, mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client, mock.patch.dict(os.environ, {"KUBECONFIG": "/another/kube/config.conf"}):
+        mock_config_path = "/OVERRIDE.conf"
+
+        client = KubeClient(kube_config_path=mock_config_path)
+
+        assert client.core == mock_kube_client.CoreV1Api()
+        mock_load_config.assert_called_once_with(config_file=mock_config_path, context=None)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ passenv = PIP_INDEX_URL
 deps =
     -rrequirements-dev.txt
 commands =
-    pip install -e .[mesos_executor,persistence]
+    pip install -e .[mesos_executor,persistence,k8s]
     - pip install yelp-meteorite
     mypy task_processing
     pytest {posargs:tests}/unit
@@ -47,7 +47,7 @@ commands =
 basepython = /usr/bin/python3.6
 envdir = venv
 commands =
-    pip install -e .[mesos_executor,metrics,persistence]
+    pip install -e .[mesos_executor,metrics,persistence,k8s]
 
 [flake8]
 exclude = .git,__pycache__,.tox,docs,venv


### PR DESCRIPTION
Much like in paasta-tools, we want to ensure that anything talking to
the k8s API has loaded the correct kubeconfig so that it knows what
master to talk to as well as what user/certs to use.