### PR TITLE
Add a way to track task metadata in k8s plugin

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -1,24 +1,67 @@
+import threading
+import time
+from enum import auto
+from enum import unique
+
+from pyrsistent import field
+from pyrsistent import pmap
+from pyrsistent import PRecord
+from pyrsistent.typing import PMap
+
 from task_processing.interfaces import TaskExecutor
 from task_processing.plugins.kubernetes.kube_client import KubeClient
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
+from task_processing.utils import AutoEnum
+
+
+@unique
+class KubernetesTaskState(AutoEnum):
+    TASK_PENDING = auto()
+
+
+class KubernetesTaskMetadata(PRecord):
+    # what box this task/Pod was scheduled onto
+    node_name: str = field(type=str, initial='')
+
+    # the config used to launch this task/Pod
+    task_config: KubernetesTaskConfig = field(type=KubernetesTaskConfig, mandatory=True)
+
+    # TODO(TASKPROC-241): add current task state and task state history as we did for mesos
+    task_state: KubernetesTaskState = field(type=KubernetesTaskState, mandatory=True)
+    # Map of state to when that state was entered (stored as a timestamp)
+    task_state_history: PMap[str, int] = field(factory=pmap, mandatory=True)
 
 
 class KubernetesPodExecutor(TaskExecutor):
     TASK_CONFIG_INTERFACE = KubernetesTaskConfig
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.kube_client = KubeClient()
+        self.task_metadata: PMap[str, KubernetesTaskMetadata] = pmap()
+        self._lock = threading.RLock()
 
-    def run(self, task_config):
+    def run(self, task_config: KubernetesTaskConfig) -> None:
+        # we need to lock here since there will be other threads updating this metadata in response
+        # to k8s events
+        with self._lock:
+            self.task_metadata = self.task_metadata.set(
+                task_config.pod_name,
+                KubernetesTaskMetadata(
+                    task_config=task_config,
+                    task_state=KubernetesTaskState.TASK_PENDING,
+                    task_state_history={KubernetesTaskState.TASK_PENDING.value: int(time.time())},
+                ),
+            )
+
+        # TODO(TASKPROC-231): actually launch a Pod
+
+    def reconcile(self, task_config: KubernetesTaskConfig) -> None:
         pass
 
-    def reconcile(self, task_config):
+    def kill(self, task_id: str) -> bool:
         pass
 
-    def kill(self, task_id):
-        pass
-
-    def stop(self):
+    def stop(self) -> None:
         pass
 
     def get_event_queue(self):

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -9,6 +9,7 @@ from pyrsistent import pmap
 from pyrsistent import PRecord
 from pyrsistent import PVector
 from pyrsistent import pvector
+from pyrsistent import v
 from pyrsistent.typing import PMap
 from pyrsistent.typing import PVector as PVectorType
 
@@ -54,7 +55,7 @@ class KubernetesPodExecutor(TaskExecutor):
                 KubernetesTaskMetadata(
                     task_config=task_config,
                     task_state=KubernetesTaskState.TASK_PENDING,
-                    task_state_history=pvector(
+                    task_state_history=v(
                         (KubernetesTaskState.TASK_PENDING, int(time.time()))
                     ),
                 ),

--- a/task_processing/utils.py
+++ b/task_processing/utils.py
@@ -1,4 +1,28 @@
+from enum import Enum
+from typing import Any
+from typing import List
+
 import yaml
+
+
+class AutoEnum(Enum):
+    """
+    Enums in Python require that some methods be defined pre-construction if overrides are
+    desired, so if we want to create an enum that sets the value of all members to the name
+    of said members, we need to create an Enum class that overrides _generate_next_value_ such
+    that when EnumBase does its magic, it sees this method.
+
+    Based on the snippet in https://docs.python.org/3/library/enum.html#using-automatic-values
+    """
+    @staticmethod
+    def _generate_next_value_(
+        name: str,
+        start: int,
+        count: int,
+        last_values: List[Any],
+    ) -> str:
+        """Override auto() to set all enum values to the name of the member"""
+        return name
 
 
 def get_cluster_master_by_proxy(

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from pyrsistent import pmap
-from pyrsistent import pvector
+from pyrsistent import v
 
 from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesPodExecutor
 from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesTaskMetadata
@@ -24,7 +24,7 @@ def test_run_updates_task_metadata(k8s_executor):
     assert k8s_executor.task_metadata == pmap(
         {
             task_config.pod_name: KubernetesTaskMetadata(
-                task_state_history=pvector((KubernetesTaskState.TASK_PENDING, mock.ANY)),
+                task_state_history=v((KubernetesTaskState.TASK_PENDING, mock.ANY)),
                 task_config=task_config,
                 node_name='',
                 task_state=KubernetesTaskState.TASK_PENDING,

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -12,9 +13,16 @@ from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 
 @pytest.fixture
 def k8s_executor():
-    executor = KubernetesPodExecutor()
-    yield executor
-    executor.stop()
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ), mock.patch.dict(os.environ, {"KUBECONFIG": "/this/doesnt/exist.conf"}):
+        executor = KubernetesPodExecutor()
+        yield executor
+        executor.stop()
 
 
 def test_run_updates_task_metadata(k8s_executor):

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -1,0 +1,32 @@
+from unittest import mock
+
+import pytest
+from pyrsistent import pmap
+
+from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesPodExecutor
+from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesTaskMetadata
+from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesTaskState
+from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
+
+
+@pytest.fixture
+def k8s_executor():
+    executor = KubernetesPodExecutor()
+    yield executor
+    executor.stop()
+
+
+def test_run_updates_task_metadata(k8s_executor):
+    task_config = KubernetesTaskConfig(name="name", uuid="uuid")
+    k8s_executor.run(task_config=task_config)
+
+    assert k8s_executor.task_metadata == pmap(
+        {
+            task_config.pod_name: KubernetesTaskMetadata(
+                task_state_history={'TASK_PENDING': mock.ANY},
+                task_config=task_config,
+                node_name='',
+                task_state=KubernetesTaskState.TASK_PENDING,
+            ),
+        },
+    )

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from pyrsistent import pmap
+from pyrsistent import pvector
 
 from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesPodExecutor
 from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesTaskMetadata
@@ -23,7 +24,7 @@ def test_run_updates_task_metadata(k8s_executor):
     assert k8s_executor.task_metadata == pmap(
         {
             task_config.pod_name: KubernetesTaskMetadata(
-                task_state_history={'TASK_PENDING': mock.ANY},
+                task_state_history=pvector((KubernetesTaskState.TASK_PENDING, mock.ANY)),
                 task_config=task_config,
                 node_name='',
                 task_state=KubernetesTaskState.TASK_PENDING,


### PR DESCRIPTION
We'll use this in the same way as we handled things in the mesos plugin:
run/kill will direfctly mutate the task_metadata member I'm adding in this PR
and we'll eventually have the thread(s?) that handle watching Pods also
add to this member in addition to the event queue that we'll share with
Tron