### PR TITLE
Teach k8s plugin how to kill a Pod

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -82,6 +82,7 @@ class KubernetesPodExecutor(TaskExecutor):
         # NOTE: we're purposely not removing this task from `task_metadata` as we want
         # to handle that with the Watch that we'll set to monitor each Pod for events.
         # TODO(TASKPROC-242): actually handle termination events
+        logger.info(f"Attempting to terminate Pod: {task_id}")
         try:
             status: V1Status = self.kube_client.core.delete_namespaced_pod(
                 name=task_id,

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -81,6 +81,7 @@ class KubernetesPodExecutor(TaskExecutor):
         """
         # NOTE: we're purposely not removing this task from `task_metadata` as we want
         # to handle that with the Watch that we'll set to monitor each Pod for events.
+        # TODO(TASKPROC-242): actually handle termination events
         try:
             status: V1Status = self.kube_client.core.delete_namespaced_pod(
                 name=task_id,

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -39,21 +39,3 @@ def test_run_updates_task_metadata(k8s_executor):
             ),
         },
     )
-
-
-def test_kill_removes_task_metadata(k8s_executor):
-    task_config = KubernetesTaskConfig(name="name", uuid="uuid")
-    k8s_executor.task_metadata = pmap(
-        {
-            task_config.pod_name: KubernetesTaskMetadata(
-                task_state_history=v((KubernetesTaskState.TASK_PENDING, 0)),
-                task_config=task_config,
-                node_name='',
-                task_state=KubernetesTaskState.TASK_PENDING,
-            ),
-        },
-    )
-
-    k8s_executor.kill(task_id=task_config.pod_name)
-
-    assert k8s_executor.task_metadata == pmap({})


### PR DESCRIPTION
This also adds in `namespace` as a required parameter for creating a k8s
executor instance.