### PR TITLE
Unpin mypy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,10 @@ flake8
 # pin hypothesis since we don't want to switch to testing p37-only until we move tron to py37
 hypothesis==4.57.1
 mock
-mypy==0.560
+mypy
 pre-commit
 pytest
 pytest-cov
 pytest-mock
+types-pyyaml
+types-requests

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -35,7 +35,7 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
             )
         )
 
-    uuid = field(type=str, initial=_generate_pod_suffix)
+    uuid = field(type=str, initial=_generate_pod_suffix)  # type: ignore
     name = field(type=str, initial="default")
     node_selector = field(type=PMap)
     containers = field(type=PVector)
@@ -51,7 +51,7 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
 
     @property
     def pod_name(self) -> str:
-        return f'{self.name}.{self.uuid}'
+        return f'{self.name}.{self.uuid}'  # type: ignore
 
     def set_pod_name(self, pod_name: str):
         try:

--- a/task_processing/plugins/mesos/task_config.py
+++ b/task_processing/plugins/mesos/task_config.py
@@ -57,7 +57,7 @@ class MesosTaskConfig(DefaultTaskConfigInterface):
             ),
         )
 
-    uuid = field(type=(str, uuid.UUID), initial=uuid.uuid4)
+    uuid = field(type=(str, uuid.UUID), initial=uuid.uuid4)  # type: ignore
     name = field(type=str, initial="default")
     # image is optional for the mesos containerizer
     image = field(type=str)

--- a/task_processing/plugins/mesos/translator.py
+++ b/task_processing/plugins/mesos/translator.py
@@ -89,7 +89,7 @@ def make_mesos_command_info(task_config: MesosTaskConfig) -> addict.Dict:
 
 def make_task_environment_variables(task_config: MesosTaskConfig) -> addict.Dict:
     env = dict(task_config.environment.items())
-    env['MESOS_TASK_ID'] = task_config.task_id
+    env['MESOS_TASK_ID'] = task_config.task_id  # type: ignore
     return addict.Dict(variables=[addict.Dict(name=k, value=v) for k, v in env.items()])
 
 


### PR DESCRIPTION
We pinned mypy ~2 years ago, but this means that we can't use certain
new-ish typing features such as the TypedDict backport in
typing-extensions.

I've unpinned mypy and added `# type: ignore` comments to all the
existing typing violations as they're all pyrsistent-related (which
makes sense since I doubt the typestubs for pyrsistent handle all
possible use-cases)