### PR TITLE
Add skeleton of Pod event processing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setup(
     packages=find_packages(exclude=('tests')),
     include_package_data=True,
     install_requires=[
+        # used for immutable data structures
         'pyrsistent',
+        # until we can drop py36, used for things like TypedDicts
+        'typing-extensions',
     ],
     extras_require={
         # We can add the Mesos specific dependencies here

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -1,61 +1,103 @@
 import logging
 import threading
 import time
-from enum import auto
-from enum import unique
-from typing import Tuple
+from queue import Queue
+from typing import Optional
+from typing import Union
 
+from kubernetes import watch
 from kubernetes.client import V1Status
-from pyrsistent import field
 from pyrsistent import pmap
-from pyrsistent import PRecord
-from pyrsistent import PVector
-from pyrsistent import pvector
 from pyrsistent import v
 from pyrsistent.typing import PMap
-from pyrsistent.typing import PVector as PVectorType
 
 from task_processing.interfaces import TaskExecutor
+from task_processing.interfaces.event import Event
 from task_processing.plugins.kubernetes.kube_client import KubeClient
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
-from task_processing.utils import AutoEnum
+from task_processing.plugins.kubernetes.types import KubernetesTaskMetadata
+from task_processing.plugins.kubernetes.types import KubernetesTaskState
+from task_processing.plugins.kubernetes.types import PodEvent
+from task_processing.plugins.kubernetes.types import Sentinel
 
 logger = logging.getLogger(__name__)
-
-
-@unique
-class KubernetesTaskState(AutoEnum):
-    TASK_PENDING = auto()
-
-
-class KubernetesTaskMetadata(PRecord):
-    # what box this task/Pod was scheduled onto
-    node_name: str = field(type=str, initial='')
-
-    # the config used to launch this task/Pod
-    task_config: KubernetesTaskConfig = field(type=KubernetesTaskConfig, mandatory=True)
-
-    # TODO(TASKPROC-241): add current task state and task state history as we did for mesos
-    task_state: KubernetesTaskState = field(type=KubernetesTaskState, mandatory=True)
-    # Map of state to when that state was entered (stored as a timestamp)
-    task_state_history: PVectorType[Tuple[KubernetesTaskState, int]] = field(
-        type=PVector, factory=pvector, mandatory=True)
 
 
 class KubernetesPodExecutor(TaskExecutor):
     TASK_CONFIG_INTERFACE = KubernetesTaskConfig
 
-    def __init__(self, namespace: str) -> None:
-        self.kube_client = KubeClient()
+    def __init__(self, namespace: str, kube_config_path: Optional[str] = None) -> None:
+        self.kube_client = KubeClient(kube_config_path=kube_config_path)
         self.namespace = namespace
 
         self.task_metadata: PMap[str, KubernetesTaskMetadata] = pmap()
-        self._lock = threading.RLock()
+        self.task_metadata_lock = threading.RLock()
+
+        # we have two queues since we need to process Pod Events into something that we can place
+        # onto the queue that any application (e.g., something like Tron or Jolt) can actually use
+        # and we've opted to not do that processing in the Pod event watcher thread so as to keep
+        # that logic for the threads that operate on them as simple as possible and to make it
+        # possible to cleanly shutdown both of these.
+        # XXX: these can probably be converted to SimpleQueue once all consumers are py37+
+        self.pending_events: "Queue[Union[PodEvent, Sentinel]]" = Queue()
+        self.event_queue: "Queue[Event]" = Queue()
+
+        # TODO(TASKPROC-243): keep track of resourceVersion so that we can continue event processing
+        # from where we left off on restarts
+        self.watch = watch.Watch()
+        self.pod_event_watch_thread = threading.Thread(
+            target=self._pod_event_watch_loop,
+            # ideally this wouldn't be a daemon thread, but a watch.Watch() only checks
+            # if it should stop after receiving an event - and it's possible that we
+            # have periods with no events so instead we'll attempt to stop the watch
+            # and then join() with a small timeout to make sure that, if we shutdown
+            # with the thread alive, we did not drop any events
+            daemon=True,
+        )
+        self.pod_event_watch_thread.start()
+
+        self.pending_event_processing_thread = threading.Thread(
+            target=self._pending_event_processing_loop,
+        )
+        self.pending_event_processing_thread.start()
+
+    def _pod_event_watch_loop(self) -> None:
+        # TODO(TASKPROC-243): we'll need to correctly handle resourceVersion expiration for the case
+        # where the gap between task_proc shutting down and coming back up is long enough for data
+        # to have expired from etcd
+        for pod_event in self.watch.stream(
+            self.kube_client.core.list_namespaced_pod,
+            self.namespace
+        ):
+            self.pending_events.put(pod_event)
+
+    def _pending_event_processing_loop(self) -> None:
+        while True:
+            event = self.pending_events.get()  # blocks forever until an event is available
+            if event is Sentinel.POISON_PILL:
+                return
+
+            # we need to narrow the types here since mypy isn't smart enough to see that the `is`
+            # check above means that we can no longer have anything but a PodEvent after it
+            assert not isinstance(event, Sentinel)
+
+            # XXX: ensure that anything here that updates self.task_metadata acquires a lock on it
+            if event["type"] == "ADDED":
+                pass
+            elif event["type"] == "DELETED":
+                pass
+            elif event["type"] == "MODIFIED":
+                pass
+            else:
+                logger.warning("Got unknown event with type: {event['type']}")
+
+            # TODO(TASKPROC-245): actually create real events to send to Tron by placing them in
+            # this plugin's event queue
 
     def run(self, task_config: KubernetesTaskConfig) -> None:
         # we need to lock here since there will be other threads updating this metadata in response
         # to k8s events
-        with self._lock:
+        with self.task_metadata_lock:
             self.task_metadata = self.task_metadata.set(
                 task_config.pod_name,
                 KubernetesTaskMetadata(
@@ -70,6 +112,9 @@ class KubernetesPodExecutor(TaskExecutor):
         # TODO(TASKPROC-231): actually launch a Pod
 
     def reconcile(self, task_config: KubernetesTaskConfig) -> None:
+        # TASKPROC(244): we probably only want reconcile() to fill in the task_config
+        # member of the relevant KubernetesTaskMetadata and do an unconditional state
+        # reconciliation on startup
         pass
 
     def kill(self, task_id: str) -> bool:
@@ -104,7 +149,20 @@ class KubernetesPodExecutor(TaskExecutor):
         return status.status == "Success"
 
     def stop(self) -> None:
-        pass
+        # make sure that we've stopped watching for events before calling join() - otherwise,
+        # join() will block until we hit the configured timeout (or forever with no timeout).
+        self.watch.stop()
+        # timeout arbitrarily chosen - we mostly just want to make sure that we have a small
+        # grace period to flush the current event to the pending_events queue as well as
+        # any other clean-up  - it's possible that after this join() the thread is still alive
+        # but in that case we can be reasonably sure that we're not dropping any data.
+        self.pod_event_watch_thread.join(timeout=1.0)
 
-    def get_event_queue(self):
-        pass
+        # once we've stopped updating the pending events queue, we can also stop processing those
+        # event since we block this thread until there's something in the queue, we need to enqueue
+        # something that will tell that thread to stop, so we use the "poison pill" pattern
+        self.pending_events.put(Sentinel.POISON_PILL)
+        self.pending_event_processing_thread.join(timeout=1.0)  # timeout also arbitrarily chosen
+
+    def get_event_queue(self) -> "Queue[Event]":
+        return self.event_queue

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -1,9 +1,9 @@
 import logging
+import queue
 import threading
 import time
 from queue import Queue
 from typing import Optional
-from typing import Union
 
 from kubernetes import watch
 from kubernetes.client import V1Status
@@ -18,9 +18,12 @@ from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 from task_processing.plugins.kubernetes.types import KubernetesTaskMetadata
 from task_processing.plugins.kubernetes.types import KubernetesTaskState
 from task_processing.plugins.kubernetes.types import PodEvent
-from task_processing.plugins.kubernetes.types import Sentinel
 
 logger = logging.getLogger(__name__)
+
+POD_WATCH_THREAD_JOIN_TIMEOUT_S = 1.0
+POD_EVENT_THREAD_JOIN_TIMEOUT_S = 1.0
+QUEUE_GET_TIMEOUT_S = 0.5
 
 
 class KubernetesPodExecutor(TaskExecutor):
@@ -40,8 +43,7 @@ class KubernetesPodExecutor(TaskExecutor):
         # and we've opted to not do that processing in the Pod event watcher thread so as to keep
         # that logic for the threads that operate on them as simple as possible and to make it
         # possible to cleanly shutdown both of these.
-        # XXX: these can probably be converted to SimpleQueue once all consumers are py37+
-        self.pending_events: "Queue[Union[PodEvent, Sentinel]]" = Queue()
+        self.pending_events: "Queue[PodEvent]" = Queue()
         self.event_queue: "Queue[Event]" = Queue()
 
         # TODO(TASKPROC-243): keep track of resourceVersion so that we can continue event processing
@@ -64,6 +66,7 @@ class KubernetesPodExecutor(TaskExecutor):
         self.pending_event_processing_thread.start()
 
     def _pod_event_watch_loop(self) -> None:
+        logger.debug(f"Starting watching Pod events for namespace={self.namespace}.")
         # TODO(TASKPROC-243): we'll need to correctly handle resourceVersion expiration for the case
         # where the gap between task_proc shutting down and coming back up is long enough for data
         # to have expired from etcd as well as actually restarting from the last resourceVersion in
@@ -74,10 +77,23 @@ class KubernetesPodExecutor(TaskExecutor):
                     self.kube_client.core.list_namespaced_pod,
                     self.namespace
                 ):
-                    self.pending_events.put(pod_event)
+                    # it's possible that we've received an event after we've already set the stop
+                    # flag since Watch streams block forever, so re-check if we've stopped before
+                    # queueing any pending events
+                    if not self.stopping:
+                        logger.debug("Adding Pod event to pending event queue.")
+                        self.pending_events.put(pod_event)
+                    else:
+                        break
             except Exception:
-                logger.exception(
-                    "Exception encountered while watching Pod events - restarting watch!")
+                # we want to avoid a potentially misleading log message should we encounter
+                # an exception when we want to shutdown this thread since nothing of value
+                # will be lost anyway (example scenario: we've called stop() on an idle cluster
+                # but the Watch is still blocking and eventually gets disconnected)
+                if not self.stopping:
+                    logger.exception(
+                        "Exception encountered while watching Pod events - restarting watch!")
+        logger.debug("Exiting Pod event watcher - stop requested.")
 
     def _process_pod_event(self, event: PodEvent) -> None:
         # XXX: ensure that anything here that updates self.task_metadata acquires a lock
@@ -94,24 +110,34 @@ class KubernetesPodExecutor(TaskExecutor):
         # this plugin's event queue
 
     def _pending_event_processing_loop(self) -> None:
+        logger.debug("Starting Pod event processing.")
         event = None
         while not self.stopping or not self.pending_events.empty():
             try:
-                event = self.pending_events.get()  # blocks forever until an event is available
-
-                if event is Sentinel.POISON_PILL:
-                    return
-                # we need to narrow the types here since mypy isn't smart enough to see that the
-                # `is` check above means that we can no longer have anything but a PodEvent after it
-                assert not isinstance(event, Sentinel)
-
+                event = self.pending_events.get(timeout=QUEUE_GET_TIMEOUT_S)
                 self._process_pod_event(event)
+            except queue.Empty:
+                logger.debug(
+                    f"Pending event queue remained empty after {QUEUE_GET_TIMEOUT_S} seconds.",
+                )
+                # we explicitly continue here as this is the only code path that doesn't
+                # need to call task_done()
+                continue
             except Exception:
                 logger.exception(
                     f"Exception encountered proccessing Pod events - skipping event {event} and "
                     "restarting processing!",
                 )
-            self.pending_events.task_done()
+
+            try:
+                self.pending_events.task_done()
+            except ValueError:
+                # this should never happen since the only codepath that should ever get
+                # here is after a successful get() - but just in case, we don't want to
+                # have this thread die because of this
+                logger.error("task_done() called on pending events queue too many times!")
+
+        logger.debug("Exiting Pod event processing - stop requested.")
 
     def run(self, task_config: KubernetesTaskConfig) -> None:
         # we need to lock here since there will be other threads updating this metadata in response
@@ -168,8 +194,10 @@ class KubernetesPodExecutor(TaskExecutor):
         return status.status == "Success"
 
     def stop(self) -> None:
+        logger.debug("Preparing to stop all KubernetesPodExecutor threads.")
         self.stopping = True
 
+        logger.debug("Signaling Pod event Watch to stop streaming events...")
         # make sure that we've stopped watching for events before calling join() - otherwise,
         # join() will block until we hit the configured timeout (or forever with no timeout).
         self.watch.stop()
@@ -177,13 +205,18 @@ class KubernetesPodExecutor(TaskExecutor):
         # grace period to flush the current event to the pending_events queue as well as
         # any other clean-up  - it's possible that after this join() the thread is still alive
         # but in that case we can be reasonably sure that we're not dropping any data.
-        self.pod_event_watch_thread.join(timeout=1.0)
+        self.pod_event_watch_thread.join(timeout=POD_WATCH_THREAD_JOIN_TIMEOUT_S)
 
-        # once we've stopped updating the pending events queue, we can also stop processing those
-        # event since we block this thread until there's something in the queue, we need to enqueue
-        # something that will tell that thread to stop, so we use the "poison pill" pattern
-        self.pending_events.put(Sentinel.POISON_PILL)
-        self.pending_event_processing_thread.join(timeout=1.0)  # timeout also arbitrarily chosen
+        logger.debug("Waiting for all pending PodEvents to be processed...")
+        # once we've stopped updating the pending events queue, we then wait until we're done
+        # processing any events we've received - this will wait until task_done() has been
+        # called for every item placed in this queue
+        self.pending_events.join()
+        logger.debug("All pending PodEvents have been processed.")
+        # and then give ourselves time to do any post-stop cleanup
+        self.pending_event_processing_thread.join(timeout=POD_EVENT_THREAD_JOIN_TIMEOUT_S)
+
+        logger.debug("Done stopping KubernetesPodExecutor!")
 
     def get_event_queue(self) -> "Queue[Event]":
         return self.event_queue

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -1,4 +1,3 @@
-import enum
 from enum import auto
 from enum import unique
 from typing import Any
@@ -15,10 +14,6 @@ from typing_extensions import TypedDict
 
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 from task_processing.utils import AutoEnum
-
-
-class Sentinel(enum.Enum):
-    POISON_PILL = object()
 
 
 class PodEvent(TypedDict):

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -1,0 +1,50 @@
+import enum
+from enum import auto
+from enum import unique
+from typing import Any
+from typing import Dict
+from typing import Tuple
+
+from kubernetes.client import V1Pod
+from pyrsistent import field
+from pyrsistent import PRecord
+from pyrsistent import PVector
+from pyrsistent import pvector
+from pyrsistent.typing import PVector as PVectorType
+from typing_extensions import TypedDict
+
+from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
+from task_processing.utils import AutoEnum
+
+
+class Sentinel(enum.Enum):
+    POISON_PILL = object()
+
+
+class PodEvent(TypedDict):
+    # there are only 3 possible types for Pod events: ADDED, DELETED, MODIFIED
+    # XXX: this should be typed as Literal["ADDED", "DELETED", "MODIFIED"] once we drop support
+    # for older Python versions
+    type: str
+    object: V1Pod
+    # this is just the dict-ified version of object - but it's too big to type here
+    raw_object: Dict[str, Any]
+
+
+@unique
+class KubernetesTaskState(AutoEnum):
+    TASK_PENDING = auto()
+
+
+class KubernetesTaskMetadata(PRecord):
+    # what box this task/Pod was scheduled onto
+    node_name: str = field(type=str, initial='')
+
+    # the config used to launch this task/Pod
+    task_config: KubernetesTaskConfig = field(type=KubernetesTaskConfig, mandatory=True)
+
+    # TODO(TASKPROC-241): add current task state and task state history as we did for mesos
+    task_state: KubernetesTaskState = field(type=KubernetesTaskState, mandatory=True)
+    # Map of state to when that state was entered (stored as a timestamp)
+    task_state_history: PVectorType[Tuple[KubernetesTaskState, int]] = field(
+        type=PVector, factory=pvector, mandatory=True)

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -9,10 +9,12 @@ from task_processing.plugins.kubernetes.kubernetes_pod_executor import Kubernete
 from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesTaskMetadata
 from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesTaskState
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
+from task_processing.plugins.kubernetes.types import PodEvent
+from task_processing.plugins.kubernetes.types import Sentinel
 
 
 @pytest.fixture
-def k8s_executor():
+def k8s_executor(mock_Thread):
     with mock.patch(
         "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
         autospec=True
@@ -39,3 +41,66 @@ def test_run_updates_task_metadata(k8s_executor):
             ),
         },
     )
+
+
+def test_pending_event_processing_loop_exits_on_poison_pill(k8s_executor):
+    k8s_executor.pending_events.put(Sentinel.POISON_PILL)
+    k8s_executor._pending_event_processing_loop()
+    assert k8s_executor.event_queue.qsize() == 0
+    assert k8s_executor.pending_events.qsize() == 0
+
+
+def test_pending_event_processing_loop_processes_events_in_order(k8s_executor):
+    k8s_executor.pending_events.put(
+        PodEvent(
+            type="ADDED",
+            object=mock.Mock(),
+            raw_object=mock.Mock(),
+        )
+    )
+
+    k8s_executor.pending_events.put(Sentinel.POISON_PILL)
+    with mock.patch.object(
+        k8s_executor,
+        "_process_pod_event",
+        autospec=True,
+    ) as mock_process_event:
+        k8s_executor._pending_event_processing_loop()
+
+    mock_process_event.assert_called_once()
+    assert k8s_executor.pending_events.qsize() == 0
+
+
+@pytest.mark.xfail(reason="_process_pod_event is still a stub function")
+def test_process_event_enqueues_task_processing_events(k8s_executor):
+    event = PodEvent(
+        type="ADDED",
+        object=mock.Mock(),
+        raw_object=mock.Mock(),
+    )
+
+    k8s_executor._process_pod_event(event)
+
+    assert k8s_executor.event_queue.qsize() == 1
+
+
+def test_pending_event_processing_loop_processes_remaining_events_after_stop(k8s_executor):
+    k8s_executor.pending_events.put(
+        PodEvent(
+            type="ADDED",
+            object=mock.Mock(),
+            raw_object=mock.Mock(),
+        )
+    )
+    k8s_executor.stopping = True
+    k8s_executor.pending_events.put(Sentinel.POISON_PILL)
+
+    with mock.patch.object(
+        k8s_executor,
+        "_process_pod_event",
+        autospec=True,
+    ) as mock_process_event:
+        k8s_executor._pending_event_processing_loop()
+
+    mock_process_event.assert_called_once()
+    assert k8s_executor.pending_events.qsize() == 0


### PR DESCRIPTION
We'll have two threads: one that simply tails a k8s stream of Pod events
and places these into an internal queue and a second one that takes
these events and (potentially) converts them into task_processing Events
and/or takes some form of action on them (e.g., removing a Pod from the
plugin's task_metadata data structure)

For now the thread that creates Events is mostly just a stub though.