### PR TITLE
Rename kube_config_path to kubeconfig_path

### DIFF
--- a/task_processing/plugins/kubernetes/kube_client.py
+++ b/task_processing/plugins/kubernetes/kube_client.py
@@ -6,16 +6,16 @@ from kubernetes import config as kube_config
 
 
 class KubeClient:
-    def __init__(self, kube_config_path: Optional[str] = None) -> None:
-        kube_config_path = kube_config_path or os.environ.get("KUBECONFIG")
-        if kube_config_path is None:
+    def __init__(self, kubeconfig_path: Optional[str] = None) -> None:
+        kubeconfig_path = kubeconfig_path or os.environ.get("KUBECONFIG")
+        if kubeconfig_path is None:
             raise ValueError(
                 "No kubeconfig specified: set a KUBECONFIG environment variable "
-                "or pass a value for `kube_config_path`!"
+                "or pass a value for `kubeconfig_path`!"
             )
 
         kube_config.load_kube_config(
-            config_file=kube_config_path,
+            config_file=kubeconfig_path,
             context=os.environ.get("KUBECONTEXT")
         )
 

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -29,8 +29,8 @@ QUEUE_GET_TIMEOUT_S = 0.5
 class KubernetesPodExecutor(TaskExecutor):
     TASK_CONFIG_INTERFACE = KubernetesTaskConfig
 
-    def __init__(self, namespace: str, kube_config_path: Optional[str] = None) -> None:
-        self.kube_client = KubeClient(kube_config_path=kube_config_path)
+    def __init__(self, namespace: str, kubeconfig_path: Optional[str] = None) -> None:
+        self.kube_client = KubeClient(kubeconfig_path=kubeconfig_path)
         self.namespace = namespace
 
         self.stopping = False

--- a/tests/unit/plugins/kubernetes/kube_client_test.py
+++ b/tests/unit/plugins/kubernetes/kube_client_test.py
@@ -25,7 +25,7 @@ def test_KubeClient_kubeconfig_init():
         "task_processing.plugins.kubernetes.kube_client.kube_client",
         autospec=True
     ) as mock_kube_client:
-        client = KubeClient(kube_config_path="/some/kube/config.conf")
+        client = KubeClient(kubeconfig_path="/some/kube/config.conf")
 
         assert client.core == mock_kube_client.CoreV1Api()
 
@@ -53,7 +53,7 @@ def test_KubeClient_kubeconfig_init_overrides_env_var():
     ) as mock_kube_client, mock.patch.dict(os.environ, {"KUBECONFIG": "/another/kube/config.conf"}):
         mock_config_path = "/OVERRIDE.conf"
 
-        client = KubeClient(kube_config_path=mock_config_path)
+        client = KubeClient(kubeconfig_path=mock_config_path)
 
         assert client.core == mock_kube_client.CoreV1Api()
         mock_load_config.assert_called_once_with(config_file=mock_config_path, context=None)


### PR DESCRIPTION
The file is generally called a kubeconfig file, so we should be
consistent with that