### PR TITLE
Make task_processing PEP-561 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,10 @@ setup(
     author='Task Processing',
     author_email='team-taskproc@yelp.com',
     description='Framework for task processing executors and configuration',
-    packages=find_packages(exclude=('tests')),
-    include_package_data=True,
+    packages=find_packages(exclude=('tests*', "examples*")),
+    package_data={
+        "task_processing": ["py.typed"]
+    },
     install_requires=[
         # used for immutable data structures
         'pyrsistent',


### PR DESCRIPTION
Without this, mypy won't attempt to use our inline types when we're included
as a dependency.

I also moved us away from `include_package_data=True`, as I don't really
think it's worth having a `MANIFEST.in` file for adding datafiles when we
can just do it inline in our `setup.py`.

Additionally, I removed examples from our packaging since those are only
useful when people are playing around with `task_processing` development.

For more info on `py.typed`:
[PEP](https://www.python.org/dev/peps/pep-0561/#packaging-type-information)
[mypy docs](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages)