### PR TITLE
Add resource limits, caps, env vars, and volumes to k8s task_config

### DIFF
--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -165,7 +165,7 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         type=float,
         initial=128.0,
         factory=float,
-        invariant=lambda m: (m >= 128, 'mem is >= 128'))
+        invariant=lambda m: (m >= 32, 'mem is >= 32'))
     disk = field(
         type=float,
         initial=10.0,

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -1,10 +1,20 @@
 import re
 import secrets
 import string
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import TYPE_CHECKING
 
 from pyrsistent import field
+from pyrsistent import m
 from pyrsistent import PMap
+from pyrsistent import pmap
 from pyrsistent import PVector
+from pyrsistent import pvector
+from pyrsistent import v
+if TYPE_CHECKING:
+    from task_processing.plugins.kubernetes.types import DockerVolume
 
 from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
 
@@ -12,10 +22,94 @@ POD_SUFFIX_ALPHABET = string.ascii_lowercase + string.digits
 POD_SUFFIX_LENGTH = 6
 MAX_POD_NAME_LENGTH = 253
 VALID_POD_NAME_REGEX = '[a-z0-9]([.-a-z0-9]*[a-z0-9])?'
+VALID_VOLUME_KEYS = {'mode', 'container_path', 'host_path'}
+VALID_CAPABILITIES = {
+    "AUDIT_CONTROL",
+    "AUDIT_READ",
+    "AUDIT_WRITE",
+    "BLOCK_SUSPEND",
+    "CHOWN",
+    "DAC_OVERRIDE",
+    "DAC_READ_SEARCH",
+    "FOWNER",
+    "FSETID",
+    "IPC_LOCK",
+    "IPC_OWNER",
+    "KILL",
+    "LEASE",
+    "LINUX_IMMUTABLE",
+    "MAC_ADMIN",
+    "MAC_OVERRIDE",
+    "MKNOD",
+    "NET_ADMIN",
+    "NET_BIND_SERVICE",
+    "NET_BROADCAST",
+    "NET_RAW",
+    "SETFCAP",
+    "SETGID",
+    "SETPCAP",
+    "SETUID",
+    "SYSLOG",
+    "SYS_ADMIN",
+    "SYS_BOOT",
+    "SYS_CHROOT",
+    "SYS_MODULE",
+    "SYS_NICE",
+    "SYS_PACCT",
+    "SYS_PTRACE",
+    "SYS_RAWIO",
+    "SYS_RESOURCE",
+    "SYS_TIME",
+    "SYS_TTY_CONFIG",
+    "WAKE_ALARM",
+}
+DEFAULT_CAPS_DROP = {
+    "AUDIT_WRITE",
+    "CHOWN",
+    "DAC_OVERRIDE",
+    "FOWNER",
+    "FSETID",
+    "KILL",
+    "MKNOD",
+    "NET_BIND_SERVICE",
+    "NET_RAW",
+    "SETFCAP",
+    "SETGID",
+    "SETPCAP",
+    "SETUID",
+    "SYS_CHROOT",
+}
+VALID_DOCKER_VOLUME_MODES = {"RW", "RO"}
 
 
 def _generate_pod_suffix() -> str:
     return ''.join(secrets.choice(POD_SUFFIX_ALPHABET) for i in range(POD_SUFFIX_LENGTH))
+
+
+def _valid_volumes(volumes: Sequence["DockerVolume"]) -> Tuple[bool, Optional[str]]:
+    for volume in volumes:
+        if set(volume.keys()) != VALID_VOLUME_KEYS:
+            return (
+                False,
+                f'Invalid volume format, must only contain following keys: '
+                f'{VALID_VOLUME_KEYS}, got: {volume.keys()}'
+            )
+        if volume["mode"] not in VALID_DOCKER_VOLUME_MODES:
+            return (
+                False,
+                f"Invalid mode for volume, must be one of {VALID_DOCKER_VOLUME_MODES}",
+            )
+    return (True, None)
+
+
+def _valid_capabilities(capabilities: Sequence[str]) -> Tuple[bool, Optional[str]]:
+    if (set(capabilities) & VALID_CAPABILITIES) != set(capabilities):
+        return (
+            False,
+            f"Invalid capabilities - got {capabilities} but expected only values from "
+            f"{VALID_CAPABILITIES}",
+        )
+    return (True, None)
 
 
 class KubernetesTaskConfig(DefaultTaskConfigInterface):
@@ -37,21 +131,64 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
 
     uuid = field(type=str, initial=_generate_pod_suffix)  # type: ignore
     name = field(type=str, initial="default")
-    image = field(type=str, mandatory=True)
-    command = field(type=str,
-                    mandatory=True,
-                    invariant=lambda cmd: (cmd.strip() != '', 'empty command is not allowed'))
     node_selector = field(type=PMap)
     # Hardcoded for the time being
     restart_policy = "Never"
     # By default, the retrying executor retries 3 times. This task option
     # overrides the executor setting.
-    retries = field(type=int,
-                    factory=int,
-                    mandatory=False,
-                    invariant=lambda r: (r >= 0, 'retries >= 0'))
-    # TODO (TASKPROC-238): Add volume, cpu, gpu, desk, mem, etc.
-    volumes = field(type=PVector)
+    retries = field(
+        type=int,
+        factory=int,
+        mandatory=False,
+        invariant=lambda r: (r >= 0, 'retries >= 0')
+    )
+
+    image = field(type=str, mandatory=True)
+    command = field(
+        type=str,
+        mandatory=True,
+        invariant=lambda cmd: (cmd.strip() != '', 'empty command is not allowed')
+    )
+    volumes = field(
+        type=PVector if not TYPE_CHECKING else PVector["DockerVolume"],
+        initial=v(),
+        factory=pvector,
+        invariant=_valid_volumes,
+    )
+
+    cpus = field(
+        type=float,
+        initial=0.1,
+        factory=float,
+        invariant=lambda c: (c > 0, 'cpus > 0'))
+    memory = field(
+        type=float,
+        initial=128.0,
+        factory=float,
+        invariant=lambda m: (m >= 128, 'mem is >= 128'))
+    disk = field(
+        type=float,
+        initial=10.0,
+        factory=float,
+        invariant=lambda d: (d > 0, 'disk > 0'))
+    environment = field(
+        type=PMap if not TYPE_CHECKING else PMap[str, str],
+        initial=m(),
+        factory=pmap,
+    )
+
+    cap_add = field(
+        type=PVector if not TYPE_CHECKING else PVector[str],
+        initial=v(),
+        factory=pvector,
+        invariant=_valid_capabilities,
+    )
+    cap_drop = field(
+        type=PVector if not TYPE_CHECKING else PVector[str],
+        initial=pvector(DEFAULT_CAPS_DROP),
+        factory=pvector,
+        invariant=_valid_capabilities,
+    )
 
     @property
     def pod_name(self) -> str:

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -16,6 +16,12 @@ from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 from task_processing.utils import AutoEnum
 
 
+class DockerVolume(TypedDict):
+    host_path: str
+    container_path: str
+    mode: str  # XXX: Literal["RO", "RW"] once we drop older Python support
+
+
 class PodEvent(TypedDict):
     # there are only 3 possible types for Pod events: ADDED, DELETED, MODIFIED
     # XXX: this should be typed as Literal["ADDED", "DELETED", "MODIFIED"] once we drop support

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -49,3 +49,115 @@ def test_kubernetes_task_config_enforces_command_requirmenets():
     )
     with pytest.raises(InvariantException):
         task_config.set(command="")
+
+
+@pytest.mark.parametrize(
+    "capabilties", (
+        ("NOT_A_CAP",),
+        ("MKNOD", "NOT_A_CAP",),
+    )
+)
+def test_cap_add_capabilities_rejects_invalid_capabilites(capabilties):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="fake_task_name",
+            uuid="fake_id",
+            image="fake_docker_image",
+            command="fake_command",
+            cap_add=capabilties,
+        )
+
+
+@pytest.mark.parametrize(
+    "capabilties", (
+        ("CHOWN",),
+        ("MKNOD", "CHOWN",),
+    )
+)
+def test_cap_add_capabilities_valid_capabilites(capabilties):
+    task_config = KubernetesTaskConfig(
+        name="fake_task_name",
+        uuid="fake_id",
+        image="fake_docker_image",
+        command="fake_command",
+        cap_add=capabilties,
+    )
+    assert tuple(task_config.cap_add) == capabilties
+
+
+@pytest.mark.parametrize(
+    "capabilties", (
+        ("NOT_A_CAP",),
+        ("MKNOD", "NOT_A_CAP",),
+    )
+)
+def test_cap_drop_capabilities_rejects_invalid_capabilites(capabilties):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="fake_task_name",
+            uuid="fake_id",
+            image="fake_docker_image",
+            command="fake_command",
+            cap_drop=capabilties,
+        )
+
+
+@pytest.mark.parametrize(
+    "capabilties", (
+        ("CHOWN",),
+        ("MKNOD", "CHOWN",),
+    )
+)
+def test_cap_drop_capabilities_valid_capabilites(capabilties):
+    task_config = KubernetesTaskConfig(
+        name="fake_task_name",
+        uuid="fake_id",
+        image="fake_docker_image",
+        command="fake_command",
+        cap_drop=capabilties,
+    )
+    assert tuple(task_config.cap_drop) == capabilties
+
+
+@pytest.mark.parametrize(
+    "volumes", (
+        [{"host_path": "/a"}],
+        [{"host_path": "/a", "containerPath": "/b"}],
+        [{"host_path": "/a", "containerPath": "/b", "mode": "RO"}],
+        [{"host_path": "/a", "container_path": "/b", "mode": "LOL"}],
+        [
+            {"host_path": "/c", "container_path": "/d", "mode": "RO"},
+            {"host_path": "/e", "containerPath": "/f", "mode": "LOL"}
+        ],
+    )
+)
+def test_volume_rejects_invalid_specification(volumes):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="fake_task_name",
+            uuid="fake_id",
+            image="fake_docker_image",
+            command="fake_command",
+            volumes=volumes
+        )
+
+
+@pytest.mark.parametrize(
+    "volumes", (
+        ({"host_path": "/a", "container_path": "/b", "mode": "RO"},),
+        (
+            {"host_path": "/a", "container_path": "/b", "mode": "RO"},
+            {"host_path": "/c", "container_path": "/d", "mode": "RW"}
+        ),
+    )
+)
+def test_volume_valid_specification(volumes):
+    task_config = KubernetesTaskConfig(
+        name="fake_task_name",
+        uuid="fake_id",
+        image="fake_docker_image",
+        command="fake_command",
+        volumes=volumes
+    )
+
+    assert tuple(task_config.volumes) == volumes


### PR DESCRIPTION
We'll need these for:
* resource limits: to isolate resource usage per-task as we did in Mesos
* capabilties: to match the security status-quo in PaaSTA/Tron-on-Mesos
* volumes: to allow people to mount files on disk :p
* environment variables: we'll need these for both PaaSTA secrets as
  well as for normal usage (some tasks may configure
  themselves/libraries with environment variables)