### PR TITLE
Ensure that k8s pod names follow yelp conventions

### DIFF
--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -13,6 +13,8 @@ from pyrsistent import pmap
 from pyrsistent import PVector
 from pyrsistent import pvector
 from pyrsistent import v
+
+from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 if TYPE_CHECKING:
     from task_processing.plugins.kubernetes.types import DockerVolume
 
@@ -113,16 +115,16 @@ def _valid_capabilities(capabilities: Sequence[str]) -> Tuple[bool, Optional[str
 
 
 class KubernetesTaskConfig(DefaultTaskConfigInterface):
-    def __invariant__(conf):
+    def __invariant__(self):
         return (
             (
-                len(conf.pod_name) < MAX_POD_NAME_LENGTH,
+                len(get_sanitised_kubernetes_name(self.pod_name)) < MAX_POD_NAME_LENGTH,
                 (
                     f'Pod name must have up to {MAX_POD_NAME_LENGTH} characters.'
                 )
             ),
             (
-                re.match(VALID_POD_NAME_REGEX, conf.pod_name),
+                re.match(VALID_POD_NAME_REGEX, get_sanitised_kubernetes_name(self.pod_name)),
                 (
                     'Must comply with Kubernetes pod naming standards.'
                 )
@@ -192,7 +194,7 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
 
     @property
     def pod_name(self) -> str:
-        return f'{self.name}.{self.uuid}'  # type: ignore
+        return get_sanitised_kubernetes_name(f'{self.name}.{self.uuid}')  # type: ignore
 
     def set_pod_name(self, pod_name: str):
         try:

--- a/task_processing/plugins/kubernetes/utils.py
+++ b/task_processing/plugins/kubernetes/utils.py
@@ -4,6 +4,7 @@ import re
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import TYPE_CHECKING
 
 from kubernetes.client import V1Capabilities
 from kubernetes.client import V1EnvVar
@@ -14,7 +15,8 @@ from kubernetes.client import V1VolumeMount
 from pyrsistent.typing import PMap
 from pyrsistent.typing import PVector
 
-from task_processing.plugins.kubernetes.types import DockerVolume
+if TYPE_CHECKING:
+    from task_processing.plugins.kubernetes.types import DockerVolume
 
 SECRET_VALUE_REGEX = re.compile(r"^(SHARED_)?SECRET\([A-Za-z0-9_-]*\)$")
 
@@ -105,7 +107,7 @@ def get_sanitised_volume_name(volume_name: str, length_limit: int = 0) -> str:
     return sanitised_name
 
 
-def get_kubernetes_volume_mounts(volumes: PVector[DockerVolume]) -> List[V1VolumeMount]:
+def get_kubernetes_volume_mounts(volumes: PVector['DockerVolume']) -> List[V1VolumeMount]:
     """
     Given a list of volume mounts, return a list corresponding to the Kubernetes objects
     representing these mounts.
@@ -123,12 +125,12 @@ def get_kubernetes_volume_mounts(volumes: PVector[DockerVolume]) -> List[V1Volum
     ]
 
 
-def get_pod_volumes(volumes: PVector[DockerVolume]) -> List[V1Volume]:
+def get_pod_volumes(volumes: PVector['DockerVolume']) -> List[V1Volume]:
     """
     Given a list of volume mounts, return a list corresponding to the Kubernetes objects needed to
     tie the mounts to a Pod.
     """
-    unique_volumes: Dict[str, DockerVolume] = {
+    unique_volumes: Dict[str, 'DockerVolume'] = {
         get_sanitised_volume_name(f"host--{volume['host_path']}", length_limit=63): volume
         for volume in volumes
     }

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -13,7 +13,7 @@ def test_kubernetes_task_config_set_pod_name():
     )
     result = task_config.set_pod_name(pod_name="mock_pod.mock_uuid")
 
-    assert result.pod_name == "mock_pod.mock_uuid"
+    assert result.pod_name == "mock--pod.mock--uuid"
 
 
 def test_kubernetes_task_config_set_pod_name_rejects_long_name():
@@ -26,18 +26,6 @@ def test_kubernetes_task_config_set_pod_name_rejects_long_name():
 
     with pytest.raises(InvariantException):
         task_config.set(name='a' * 254)
-
-
-def test_kubernetes_task_config_enforces_kubernetes_name_requirements():
-    task_config = KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
-        image="fake_docker_image",
-        command="fake_command"
-    )
-
-    with pytest.raises(InvariantException):
-        task_config.set(name=f"INVALID{task_config.name}")
 
 
 def test_kubernetes_task_config_enforces_command_requirmenets():


### PR DESCRIPTION
We now implicitly call get_sanitised_kubernetes_name() when returning
pod names so that we don't need our users to do this.

This change does mean that `name != pod_name.split(".")[0]`, but this
should be fine