### PR TITLE
TASKPROC-249: Revert duplication of paasta logic, pass secret refs directly

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -340,8 +340,7 @@ class KubernetesPodExecutor(TaskExecutor):
                 ),
                 env=get_kubernetes_env_vars(
                     task_config.environment,
-                    task_name=task_config.name,
-                    namespace=self.namespace
+                    task_config.secret_environment,
                 ),
                 volume_mounts=get_kubernetes_volume_mounts(task_config.volumes)
             )

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -108,7 +108,7 @@ def _valid_volumes(volumes: Sequence["DockerVolume"]) -> Tuple[bool, Optional[st
 
 
 def _valid_secret_envs(secret_envs: Mapping[str, "SecretEnvSource"]) -> Tuple[bool, Optional[str]]:
-    # XXX: Note we are not validating existence of secret in k8s here, leave that to creation of pod
+    # Note we are not validating existence of secret in k8s here, leave that to creation of pod
     for key, value in secret_envs.items():
         if set(value.keys()) != VALID_SECRET_ENV_KEYS:
             return (

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -1,6 +1,7 @@
 import re
 import secrets
 import string
+from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
@@ -17,6 +18,7 @@ from pyrsistent import v
 from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 if TYPE_CHECKING:
     from task_processing.plugins.kubernetes.types import DockerVolume
+    from task_processing.plugins.kubernetes.types import SecretEnvSource
 
 from task_processing.interfaces.task_executor import DefaultTaskConfigInterface
 
@@ -25,6 +27,7 @@ POD_SUFFIX_LENGTH = 6
 MAX_POD_NAME_LENGTH = 253
 VALID_POD_NAME_REGEX = '[a-z0-9]([.-a-z0-9]*[a-z0-9])?'
 VALID_VOLUME_KEYS = {'mode', 'container_path', 'host_path'}
+VALID_SECRET_ENV_KEYS = {'secret', 'key'}
 VALID_CAPABILITIES = {
     "AUDIT_CONTROL",
     "AUDIT_READ",
@@ -104,6 +107,18 @@ def _valid_volumes(volumes: Sequence["DockerVolume"]) -> Tuple[bool, Optional[st
     return (True, None)
 
 
+def _valid_secret_envs(secret_envs: Mapping[str, "SecretEnvSource"]) -> Tuple[bool, Optional[str]]:
+    # XXX: Note we are not validating existence of secret in k8s here, leave that to creation of pod
+    for key, value in secret_envs.items():
+        if set(value.keys()) != VALID_SECRET_ENV_KEYS:
+            return (
+                False,
+                f'Invalid secret environment variable {key}, must only contain following keys: '
+                f'{VALID_SECRET_ENV_KEYS}, got: {value.keys()}'
+            )
+    return (True, None)
+
+
 def _valid_capabilities(capabilities: Sequence[str]) -> Tuple[bool, Optional[str]]:
     if (set(capabilities) & VALID_CAPABILITIES) != set(capabilities):
         return (
@@ -178,7 +193,12 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         initial=m(),
         factory=pmap,
     )
-
+    secret_environment = field(
+        type=PMap if not TYPE_CHECKING else PMap[str, 'SecretEnvSource'],
+        initial=m(),
+        factory=pmap,
+        invariant=_valid_secret_envs,
+    )
     cap_add = field(
         type=PVector if not TYPE_CHECKING else PVector[str],
         initial=v(),

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -22,6 +22,11 @@ class DockerVolume(TypedDict):
     mode: str  # XXX: Literal["RO", "RW"] once we drop older Python support
 
 
+class SecretEnvSource(TypedDict):
+    secret: str  # full name of k8s secret resource
+    key: str
+
+
 class PodEvent(TypedDict):
     # there are only 3 possible types for Pod events: ADDED, DELETED, MODIFIED
     # XXX: this should be typed as Literal["ADDED", "DELETED", "MODIFIED"] once we drop support

--- a/task_processing/plugins/kubernetes/utils.py
+++ b/task_processing/plugins/kubernetes/utils.py
@@ -1,6 +1,5 @@
 import hashlib
 import logging
-import re
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -19,9 +18,7 @@ from pyrsistent.typing import PVector
 
 if TYPE_CHECKING:
     from task_processing.plugins.kubernetes.types import DockerVolume
-
-SECRET_VALUE_REGEX = re.compile(r"^(SHARED_)?SECRET\([A-Za-z0-9_-]*\)$")
-SHARED_SECRET_SERVICE = "_shared"
+    from task_processing.plugins.kubernetes.types import SecretEnvSource
 
 logger = logging.getLogger(__name__)
 
@@ -49,74 +46,8 @@ def get_security_context_for_capabilities(
     return None
 
 
-def is_secret_env_var(value: str) -> bool:
-    """
-    Given the value of an environment variable, return if that environment variable
-    represents a secret.
-    """
-    return SECRET_VALUE_REGEX.match(value) is not None
-
-
-def get_secret_name_from_ref(value: str) -> str:
-    """
-    Given a PaaSTA-style secret reference, return the name of the secret.
-
-    Supported secret references types:
-        * SECRET(value)
-        * SHARED_SECRET(value)
-    """
-    return value.split("(")[1][:-1]
-
-
-def is_shared_secret(value: str) -> bool:
-    """
-    In some cases, multiple services need access to the same secrets - rather than storing
-    these N times internally, Yelp has a mechanism in which a secret can be tagged as
-    "shared" and thus only need to be modified in one place should that secret need to be
-    rotated/updated/etc.
-
-    These "shared" secrets are referenced using the format SHARED_SECRET(secret_name)
-    instead of the more tightly-scoped format of SECRET(secret_name)
-    """
-    return value.startswith("SHARED_")
-
-
-def get_secret_kubernetes_env_var(
-    key: str, value: str, task_name: str, namespace: str,
-) -> V1EnvVar:
-    """
-    Returns a Kubernetes EnvVar object that will pull the plaintext of a secret from the
-    Kubernetes Secrets store.
-
-    Will attempt to use the task name to retrieve the corresponding secret unless the value
-    referenced is a shared secret (in which case, a special name is used).
-
-    This expects Kubernetes Secrets to have been created by an external process matching a
-    specific naming convention based on Kubernetes namespace, task name, and the requested
-    secret name.
-
-    XXX:  document how these work internally for non-Yelpers?
-    """
-    task_prefix = task_name.split('.')[0] if not is_shared_secret(value) else SHARED_SECRET_SERVICE
-    sanitised_task_prefix = get_sanitised_kubernetes_name(task_prefix)
-
-    secret = get_secret_name_from_ref(value)
-    sanitised_secret = get_sanitised_kubernetes_name(secret)
-
-    return V1EnvVar(
-        name=key,
-        value_from=V1EnvVarSource(
-            secret_key_ref=V1SecretKeySelector(
-                name=f"{namespace}-secret-{sanitised_task_prefix}-{sanitised_secret}",
-                key=secret,
-                optional=False,
-            )
-        ),
-    )
-
-
 def get_kubernetes_env_vars(
-    environment: PMap[str, str], task_name: str, namespace: str,
+    environment: PMap[str, str], secret_environment: PMap[str, 'SecretEnvSource'],
 ) -> List[V1EnvVar]:
     """
     Given a dict of environment variables, transform them into the corresponding Kubernetes
@@ -126,17 +57,21 @@ def get_kubernetes_env_vars(
     env_vars = [
         V1EnvVar(name=key, value=value) for key, value
         in environment.items()
-        if not is_secret_env_var(value)
     ]
 
     secret_env_vars = [
-        get_secret_kubernetes_env_var(
-            key=key, value=value, task_name=task_name, namespace=namespace
+        V1EnvVar(name=key, value_from=V1EnvVarSource(
+            secret_key_ref=V1SecretKeySelector(
+                name=value["secret"],
+                key=value["key"],
+                optional=False,
+            ),
+        ),
         )
         for key, value
-        in environment.items()
-        if is_secret_env_var(value)
+        in secret_environment.items()
     ]
+
     return env_vars + secret_env_vars
 
 

--- a/task_processing/plugins/kubernetes/utils.py
+++ b/task_processing/plugins/kubernetes/utils.py
@@ -56,7 +56,7 @@ def get_kubernetes_env_vars(
     """
     env_vars = [
         V1EnvVar(name=key, value=value) for key, value
-        in environment.items()
+        in environment.items() if key not in secret_environment.keys()
     ]
 
     secret_env_vars = [

--- a/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
@@ -139,21 +139,25 @@ def test_get_kubernetes_env_vars():
 
     expected_env_vars = [
         V1EnvVar(name="FAKE_PLAIN_VAR", value="not_secret_data"),
-        V1EnvVar(name="FAKE_SECRET", value_from=V1EnvVarSource(
-            secret_key_ref=V1SecretKeySelector(
-                name="taskns-secret-taskname-some--secret--name",
-                key="some_secret_name",
-                optional=False,
+        V1EnvVar(
+            name="FAKE_SECRET",
+            value_from=V1EnvVarSource(
+                secret_key_ref=V1SecretKeySelector(
+                    name="taskns-secret-taskname-some--secret--name",
+                    key="some_secret_name",
+                    optional=False,
+                ),
             ),
         ),
-        ),
-        V1EnvVar(name="FAKE_SHARED_SECRET", value_from=V1EnvVarSource(
-            secret_key_ref=V1SecretKeySelector(
-                name="taskns-secret-underscore-shared-shared--secret-name",
-                key="shared_secret-name",
-                optional=False,
+        V1EnvVar(
+            name="FAKE_SHARED_SECRET",
+            value_from=V1EnvVarSource(
+                secret_key_ref=V1SecretKeySelector(
+                    name="taskns-secret-underscore-shared-shared--secret-name",
+                    key="shared_secret-name",
+                    optional=False,
+                ),
             ),
-        ),
         ),
     ]
     env_vars = get_kubernetes_env_vars(environment=test_env_vars,

--- a/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
@@ -165,3 +165,11 @@ def test_get_kubernetes_env_vars():
                                        )
 
     assert sorted(expected_env_vars, key=lambda x: x.name) == sorted(env_vars, key=lambda x: x.name)
+
+    test_dupe_env_vars = test_env_vars.set("FAKE_SECRET", "SECRET(not_secret_data)")
+
+    env_vars = get_kubernetes_env_vars(environment=test_dupe_env_vars,
+                                       secret_environment=test_secret_env_vars,
+                                       )
+
+    assert sorted(expected_env_vars, key=lambda x: x.name) == sorted(env_vars, key=lambda x: x.name)

--- a/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
@@ -15,11 +15,7 @@ from task_processing.plugins.kubernetes.utils import get_kubernetes_volume_mount
 from task_processing.plugins.kubernetes.utils import get_pod_volumes
 from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 from task_processing.plugins.kubernetes.utils import get_sanitised_volume_name
-from task_processing.plugins.kubernetes.utils import get_secret_kubernetes_env_var
-from task_processing.plugins.kubernetes.utils import get_secret_name_from_ref
 from task_processing.plugins.kubernetes.utils import get_security_context_for_capabilities
-from task_processing.plugins.kubernetes.utils import is_secret_env_var
-from task_processing.plugins.kubernetes.utils import is_shared_secret
 
 
 @pytest.mark.parametrize(
@@ -33,46 +29,6 @@ from task_processing.plugins.kubernetes.utils import is_shared_secret
 )
 def test_get_security_context_for_capabilities(cap_add, cap_drop, expected):
     assert get_security_context_for_capabilities(cap_add, cap_drop) == expected
-
-
-@pytest.mark.parametrize(
-    "value,expected", (
-        ("lol", False),
-        ("CAPS", False),
-        ("SECRET", False,),
-        ("SHARED_SECRET", False),
-        ("SECRET(secret)", True),
-        ("SHARED_SECRET(secret)", True),
-        ("SECRET(WOW1)", True),
-        ("SHARED_SECRET(WOAH_2)", True),
-        ("SECRET(test-2)", True),
-        ("SHARED_SECRET(WOAH_2", False),
-        ("SECRET(test-2", False),
-    )
-)
-def test_is_secret_env_var(value, expected):
-    assert is_secret_env_var(value) is expected
-
-
-@pytest.mark.parametrize(
-    "value,expected", (
-        ("SECRET(secret)", "secret"),
-        ("SHARED_SECRET(secret2)", "secret2"),
-    )
-)
-def test_get_secret_name_from_ref(value, expected):
-    assert get_secret_name_from_ref(value) == expected
-
-
-@pytest.mark.parametrize(
-    "value,expected", (
-        ("not_a_secret", False),
-        ("SECRET(secret)", False),
-        ("SHARED_SECRET(secret2)", True),
-    )
-)
-def test_is_shared_secret(value, expected):
-    assert is_shared_secret(value) is expected
 
 
 @pytest.mark.parametrize(
@@ -162,50 +118,22 @@ def test_get_pod_volumes(volumes, expected):
     assert get_pod_volumes(volumes) == expected
 
 
-@pytest.mark.parametrize(
-    "key, value, task_name, namespace, expected", (
-        ("FAKE_LOCAL_SECRET", "SECRET(plain_secret)", "taskprefix.subtask.etc", "taskns",
-            V1EnvVar(name="FAKE_LOCAL_SECRET", value_from=V1EnvVarSource(
-                secret_key_ref=V1SecretKeySelector(
-                    name="taskns-secret-taskprefix-plain--secret",
-                    key="plain_secret",
-                    optional=False
-                )
-            )
-            )
-         ),
-        ("FAKE_LOCAL_SECRET2", "SECRET(plain_secret)", "taskname", "taskns",
-            V1EnvVar(name="FAKE_LOCAL_SECRET2", value_from=V1EnvVarSource(
-                secret_key_ref=V1SecretKeySelector(
-                    name="taskns-secret-taskname-plain--secret",
-                    key="plain_secret",
-                    optional=False
-                )
-            )
-            )
-         ),
-        ("FAKE_SHARED_SECRET", "SHARED_SECRET(plain_secret)", "taskprefix", "taskns",
-            V1EnvVar(name="FAKE_SHARED_SECRET", value_from=V1EnvVarSource(
-                secret_key_ref=V1SecretKeySelector(
-                    name="taskns-secret-underscore-shared-plain--secret",
-                    key="plain_secret",
-                    optional=False
-                )
-            )
-            )
-         ),
-    )
-)
-def test_get_secret_kubernetes_env_var(key, value, task_name, namespace, expected):
-    assert get_secret_kubernetes_env_var(key, value, task_name, namespace) == expected
-
-
 def test_get_kubernetes_env_vars():
     test_env_vars = pmap(
         {
             "FAKE_PLAIN_VAR": "not_secret_data",
-            "FAKE_SECRET": "SECRET(some_secret_name)",
-            "FAKE_SHARED_SECRET": "SHARED_SECRET(shared_secret-name)",
+        }
+    )
+    test_secret_env_vars = pmap(
+        {
+            "FAKE_SECRET": {
+                "secret": "taskns-secret-taskname-some--secret--name",
+                "key": "some_secret_name"
+            },
+            "FAKE_SHARED_SECRET": {
+                "secret": "taskns-secret-underscore-shared-shared--secret-name",
+                "key": "shared_secret-name"
+            },
         }
     )
 
@@ -229,8 +157,7 @@ def test_get_kubernetes_env_vars():
         ),
     ]
     env_vars = get_kubernetes_env_vars(environment=test_env_vars,
-                                       task_name="taskname.subtask",
-                                       namespace="taskns",
+                                       secret_environment=test_secret_env_vars,
                                        )
 
     assert sorted(expected_env_vars, key=lambda x: x.name) == sorted(env_vars, key=lambda x: x.name)


### PR DESCRIPTION
in #168 , we duplicated some paasta implementation within task-proc to set up secrets in envvars.  

This wasn't going to be maintainable moving forward, so we've removed that and task_proc will simply be passed a new `secrets_environment` config specifying the name of the envvar and the required `V1SecretKeySelector` values necessary to pull from a `V1Secret`.

This makes task_processing code much cleaner and straightforward. 
