### PR TITLE
Hardcode k8s container names

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -27,7 +27,6 @@ from task_processing.plugins.kubernetes.types import PodEvent
 from task_processing.plugins.kubernetes.utils import get_kubernetes_env_vars
 from task_processing.plugins.kubernetes.utils import get_kubernetes_volume_mounts
 from task_processing.plugins.kubernetes.utils import get_pod_volumes
-from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 from task_processing.plugins.kubernetes.utils import get_security_context_for_capabilities
 
 logger = logging.getLogger(__name__)
@@ -325,7 +324,11 @@ class KubernetesPodExecutor(TaskExecutor):
         try:
             container = V1Container(
                 image=task_config.image,
-                name=get_sanitised_kubernetes_name(task_config.name, replace_dots=True),
+                # XXX: we were initially planning on using the name from KubernetesTaskConfig here,
+                # but its too easy to go over the length limit for container names (63 characters),
+                # so we're just hardcoding something for now since container names aren't used for
+                # anything at the moment
+                name="main",
                 command=["/bin/sh", "-c"],
                 args=[task_config.command],
                 security_context=get_security_context_for_capabilities(

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -21,7 +21,6 @@ from task_processing.plugins.kubernetes.kubernetes_pod_executor import Kubernete
 from task_processing.plugins.kubernetes.kubernetes_pod_executor import KubernetesTaskState
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 from task_processing.plugins.kubernetes.types import PodEvent
-from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 
 
 @pytest.fixture
@@ -72,7 +71,7 @@ def test_run(k8s_executor):
     )
     expected_container = V1Container(
         image=task_config.image,
-        name=get_sanitised_kubernetes_name(task_config.name, replace_dots=True),
+        name="main",
         command=["/bin/sh", "-c"],
         args=[task_config.command],
         security_context=V1SecurityContext(


### PR DESCRIPTION
Unfortunately, we won't be able to use the `name` attribute from
KubernetesTaskConfig to name containers as we were planning due to the
63char length limit on DNS label names - but it turns out that we don't
actually need these for anything (we initially thought our log routing
system used these names), so we'll stick with "main" for now until
there's a usecase that requires something more dynamic