### PR TITLE
Fix k8s failed platform_type casing + add TASK_LOST

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -224,7 +224,7 @@ class KubernetesPodExecutor(TaskExecutor):
         # phase)
         elif (
             pod.status.phase == "Unknown"
-            and task_metadata.task_state is not KubernetesTaskState.TASK_UNKNOWN
+            and task_metadata.task_state is not KubernetesTaskState.TASK_LOST
         ):
             logger.info(
                 f"Got a MODIFIED event for {pod_name} with unknown phase, host likely "
@@ -234,9 +234,9 @@ class KubernetesPodExecutor(TaskExecutor):
                 pod_name,
                 task_metadata.set(
                     node_name=pod.spec.node_name,
-                    task_state=KubernetesTaskState.TASK_UNKNOWN,
+                    task_state=KubernetesTaskState.TASK_LOST,
                     task_state_history=task_metadata.task_state_history.append(
-                        (KubernetesTaskState.TASK_UNKNOWN, time.time()),
+                        (KubernetesTaskState.TASK_LOST, time.time()),
                     )
                 )
             )

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -187,7 +187,7 @@ class KubernetesPodExecutor(TaskExecutor):
                     timestamp=time.time(),
                     raw=event["raw_object"],
                     task_config=task_metadata.task_config,
-                    platform_type="FAILED"
+                    platform_type="failed"
                 )
             )
             return
@@ -247,7 +247,7 @@ class KubernetesPodExecutor(TaskExecutor):
                     timestamp=time.time(),
                     raw=event["raw_object"],
                     task_config=task_metadata.task_config,
-                    platform_type="unknown"
+                    platform_type="lost"
                 )
             )
             return

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -44,6 +44,7 @@ class KubernetesTaskState(AutoEnum):
     TASK_FINISHED = auto()
     TASK_FAILED = auto()
     TASK_UNKNOWN = auto()
+    TASK_LOST = auto()
 
 
 class KubernetesTaskMetadata(PRecord):


### PR DESCRIPTION
I made a typo in the original PR added task events and somehow added an
all-caps platform_type.

Additionally, this change adds a TASK_LOST status and uses that instead
of TASK_UNKNOWN when we recieve a Pod event with a phase of Unknown
since we'll be using TASK_UNKNOWN as the initial state when we're
starting up with pre-existing state (e.g., after a Tron restart)