### PR TITLE
Fix k8s secret source definitions to use secret_name instead of secret

### DIFF
--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -27,7 +27,7 @@ POD_SUFFIX_LENGTH = 6
 MAX_POD_NAME_LENGTH = 253
 VALID_POD_NAME_REGEX = '[a-z0-9]([.-a-z0-9]*[a-z0-9])?'
 VALID_VOLUME_KEYS = {'mode', 'container_path', 'host_path'}
-VALID_SECRET_ENV_KEYS = {'secret', 'key'}
+VALID_SECRET_ENV_KEYS = {'secret_name', 'key'}
 VALID_CAPABILITIES = {
     "AUDIT_CONTROL",
     "AUDIT_READ",

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -23,7 +23,7 @@ class DockerVolume(TypedDict):
 
 
 class SecretEnvSource(TypedDict):
-    secret: str  # full name of k8s secret resource
+    secret_name: str  # full name of k8s secret resource
     key: str
 
 

--- a/task_processing/plugins/kubernetes/utils.py
+++ b/task_processing/plugins/kubernetes/utils.py
@@ -62,7 +62,7 @@ def get_kubernetes_env_vars(
     secret_env_vars = [
         V1EnvVar(name=key, value_from=V1EnvVarSource(
             secret_key_ref=V1SecretKeySelector(
-                name=value["secret"],
+                name=value["secret_name"],
                 key=value["key"],
                 optional=False,
             ),

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -154,10 +154,10 @@ def test_volume_valid_specification(volumes):
 
 @pytest.mark.parametrize(
     "secret_environment", (
-        pmap({'SECRET1': {'secret': 'taskprocns-secret-secret1', 'key': 'secret_1'}}),
+        pmap({'SECRET1': {'secret_name': 'taskprocns-secret-secret1', 'key': 'secret_1'}}),
         pmap({
-            'SECRET_A': {'secret': 'taskprocns-secret-secret--a', 'key': 'secreta'},
-            'SECRET_B': {'secret': 'taskprocns-secret-secret--b', 'key': 'secretb'},
+            'SECRET_A': {'secret_name': 'taskprocns-secret-secret--a', 'key': 'secreta'},
+            'SECRET_B': {'secret_name': 'taskprocns-secret-secret--b', 'key': 'secretb'},
         }),
     )
 )
@@ -176,9 +176,9 @@ def test_secret_env_valid_specification(secret_environment):
 @pytest.mark.parametrize(
     "secret_environment", (
         pmap({'SECRET1': {
-            'secret': 'taskprocns-secret-1', 'key': 'secret-1', 'namespace': 'otherns'
+            'secret_name': 'taskprocns-secret-1', 'key': 'secret-1', 'namespace': 'otherns'
         }}),
-        pmap({'SECRET1': {'secret': 'taskprocns-secret-2'}})
+        pmap({'SECRET1': {'secret_name': 'taskprocns-secret-2'}})
     )
 )
 def test_secret_env_rejects_invalid_specification(secret_environment):

--- a/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
@@ -127,11 +127,11 @@ def test_get_kubernetes_env_vars():
     test_secret_env_vars = pmap(
         {
             "FAKE_SECRET": {
-                "secret": "taskns-secret-taskname-some--secret--name",
+                "secret_name": "taskns-secret-taskname-some--secret--name",
                 "key": "some_secret_name"
             },
             "FAKE_SHARED_SECRET": {
-                "secret": "taskns-secret-underscore-shared-shared--secret-name",
+                "secret_name": "taskns-secret-underscore-shared-shared--secret-name",
                 "key": "shared_secret-name"
             },
         }


### PR DESCRIPTION
In https://github.com/Yelp/Tron/pull/822/files we decided to use `secret_name` as the key that held the name of the Kubernetes V1Secret resource we were using as a source for our envvars, rather than `secret`. This should minimize confusion since this field does not store any secrets itself, just the name of the secret resource.

This change updates the schema/code/tests to reflect this change. 