### PR TITLE
TASKPROC-244:  Initialize metadata via state data and implement reconcile for k8s

### DIFF
--- a/task_processing/plugins/kubernetes/kube_client.py
+++ b/task_processing/plugins/kubernetes/kube_client.py
@@ -168,8 +168,6 @@ class KubeClient:
                     namespace=namespace, name={pod_name},
                 )
                 if not pod:
-                    # XXX: We do not currently distinguish between not finding a pod and hitting api
-                    #      exception when fetching pod
                     logger.info(f"Found no pods matching {pod_name}.")
                     return None
                 else:

--- a/task_processing/plugins/kubernetes/kube_client.py
+++ b/task_processing/plugins/kubernetes/kube_client.py
@@ -167,12 +167,12 @@ class KubeClient:
                 pod = self.core.read_namespaced_pod(
                     namespace=namespace, name={pod_name},
                 )
-                if not pod:
+                return pod
+            except ApiException as e:
+                # Unknown pod throws ApiException w/ 404
+                if e.status == 404:
                     logger.info(f"Found no pods matching {pod_name}.")
                     return None
-                else:
-                    return pod
-            except ApiException as e:
                 if not self.maybe_reload_on_exception(exception=e) and attempts:
                     logger.debug(
                         f"Failed to fetch pod {pod_name} due to unhandled API exception, retrying",

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -434,7 +434,8 @@ class KubernetesPodExecutor(TaskExecutor):
         try:
             pod = self.kube_client.get_pod(namespace=self.namespace, pod_name=pod_name)
         except Exception:
-            logger.exception(f"Cannot reconcile pod {pod_name}")
+            logger.exception(f"Hit an exception attempting to fetch pod {pod_name}")
+            pod = None
 
         if pod_name not in self.task_metadata:
             self._initialize_existing_task(task_config)
@@ -448,7 +449,6 @@ class KubernetesPodExecutor(TaskExecutor):
                 )
             )
 
-        with self.task_metadata_lock:
             if not pod:
                 # Pod has gone away while restarting
                 logger.info(

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -233,7 +233,7 @@ class KubernetesPodExecutor(TaskExecutor):
             self.task_metadata = self.task_metadata.set(
                 pod_name,
                 task_metadata.set(
-                    node_name=pod.status.host_ip,
+                    node_name=pod.spec.node_name,
                     task_state=KubernetesTaskState.TASK_RUNNING,
                     task_state_history=task_metadata.task_state_history.append(
                         (KubernetesTaskState.TASK_RUNNING, time.time()),
@@ -266,7 +266,7 @@ class KubernetesPodExecutor(TaskExecutor):
             self.task_metadata = self.task_metadata.set(
                 pod_name,
                 task_metadata.set(
-                    node_name=pod.status.host_ip,
+                    node_name=pod.spec.node_name,
                     task_state=KubernetesTaskState.TASK_LOST,
                     task_state_history=task_metadata.task_state_history.append(
                         (KubernetesTaskState.TASK_LOST, time.time()),

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -427,7 +427,14 @@ class KubernetesPodExecutor(TaskExecutor):
 
     def reconcile(self, task_config: KubernetesTaskConfig) -> None:
         pod_name = task_config.pod_name
-        pod = self.kube_client.get_pod(namespace=self.namespace, pod_name=pod_name)
+        try:
+            pod = self.kube_client.get_pod(namespace=self.namespace, pod_name=pod_name)
+        except Exception:
+            logger.exception(f"Cannot reconcile pod {pod_name}")
+
+        if pod_name not in self.task_metadata:
+            logger.info(f"Cannot reconcile pod {pod_name}, not found in task metadata")
+            return
 
         with self.task_metadata_lock:
             task_metadata = self.task_metadata[pod_name]

--- a/tests/unit/plugins/kubernetes/kube_client_test.py
+++ b/tests/unit/plugins/kubernetes/kube_client_test.py
@@ -2,7 +2,9 @@ import os
 from unittest import mock
 
 import pytest
+from kubernetes.client.exceptions import ApiException
 
+from task_processing.plugins.kubernetes.kube_client import ExceededMaxAttempts
 from task_processing.plugins.kubernetes.kube_client import KubeClient
 
 
@@ -57,3 +59,36 @@ def test_KubeClient_kubeconfig_init_overrides_env_var():
 
         assert client.core == mock_kube_client.CoreV1Api()
         mock_load_config.assert_called_once_with(config_file=mock_config_path, context=None)
+
+
+def test_KubeClient_get_pod_too_many_failures():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client, mock.patch.dict(
+        os.environ, {"KUBECONFIG": "/another/kube/config.conf"}
+    ), pytest.raises(ExceededMaxAttempts):
+        mock_config_path = "/OVERRIDE.conf"
+        mock_kube_client.CoreV1Api().read_namespaced_pod.side_effect = [ApiException, ApiException]
+        client = KubeClient(kubeconfig_path=mock_config_path)
+        client.get_pod(namespace='ns', pod_name='pod-name', attempts=2)
+    assert mock_kube_client.CoreV1Api().read_namespaced_pod.call_count == 2
+
+
+def test_KubeClient_get_pod_unknown_exception():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client, mock.patch.dict(
+        os.environ, {"KUBECONFIG": "/another/kube/config.conf"}
+    ), pytest.raises(Exception):
+        mock_config_path = "/OVERRIDE.conf"
+        mock_kube_client.CoreV1Api().read_namespaced_pod.side_effect = [Exception]
+        client = KubeClient(kubeconfig_path=mock_config_path)
+        client.get_pod(namespace='ns', pod_name='pod-name', attempts=2)

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -155,7 +155,7 @@ def test_process_event_enqueues_task_processing_events_pending_to_running(k8s_ex
     mock_pod = mock.Mock(spec=V1Pod)
     mock_pod.metadata.name = "test.1234"
     mock_pod.status.phase = "Running"
-    mock_pod.status.host_ip = "1.2.3.4"
+    mock_pod.spec.node_name = "node-1-2-3-4"
     mock_event = PodEvent(
         type="MODIFIED",
         object=mock_pod,
@@ -187,7 +187,7 @@ def test_process_event_enqueues_task_processing_events_running_to_terminal(k8s_e
     mock_pod = mock.Mock(spec=V1Pod)
     mock_pod.metadata.name = "test.1234"
     mock_pod.status.phase = phase
-    mock_pod.status.host_ip = "1.2.3.4"
+    mock_pod.spec.node_name = "node-1-2-3-4"
     mock_event = PodEvent(
         type="MODIFIED",
         object=mock_pod,
@@ -224,6 +224,7 @@ def test_process_event_enqueues_task_processing_events_no_state_transition(
     mock_pod.metadata.name = "test.1234"
     mock_pod.status.phase = phase
     mock_pod.status.host_ip = "1.2.3.4"
+    mock_pod.spec.node_name = 'kubenode'
     mock_event = PodEvent(
         type="MODIFIED",
         object=mock_pod,
@@ -276,6 +277,7 @@ def test_process_event_enqueues_task_processing_events_deleted(
     mock_pod.metadata.name = "test.1234"
     mock_pod.status.phase = "Running"
     mock_pod.status.host_ip = "1.2.3.4"
+    mock_pod.spec.node_name = 'kubenode'
     mock_event = PodEvent(
         type="DELETED",
         object=mock_pod,
@@ -347,7 +349,7 @@ def test_reconcile_existing_pods(
         mock_pod.metadata.name = taskconf.pod_name
         mock_pod.status.phase = phase
         mock_pod.status.host_ip = '1.2.3.4'
-        mock_pod.status.node_name = 'kubenode'
+        mock_pod.spec.node_name = 'kubenode'
         mock_pods.append(mock_pod)
 
     with mock.patch.object(


### PR DESCRIPTION
In order to handle tron restarts, we will need to first pass kubernetes_pod_executor a list of KubernetesTaskConfigs from our saved state.

We initialize this in `kubernetes_pod_executor` upon init, filling `task_metadata` with UNKNOWN KubernetesTaskStates for each pod name to speed up initalization.

Reconciliation with said pods will then happen in `reconcile()`, where we will check the state of the pod we are attempting to reconcile with the Kubernetes API, then re-use the exact same logic to set TaskState (etc) as when we handle `PodEvents` based on pod phases.   This required splitting out said logic into two new helpers, `__update_deleted_pod` and `__update_modified_pod` so they could be used for both usecases.