### PR TITLE
Add node selectors and node affinities

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -7,6 +7,7 @@ from typing import Collection
 from typing import Optional
 
 from kubernetes import watch
+from kubernetes.client import V1Affinity
 from kubernetes.client import V1Container
 from kubernetes.client import V1ObjectMeta
 from kubernetes.client import V1Pod
@@ -27,6 +28,7 @@ from task_processing.plugins.kubernetes.task_metadata import KubernetesTaskState
 from task_processing.plugins.kubernetes.types import PodEvent
 from task_processing.plugins.kubernetes.utils import get_kubernetes_env_vars
 from task_processing.plugins.kubernetes.utils import get_kubernetes_volume_mounts
+from task_processing.plugins.kubernetes.utils import get_node_affinity
 from task_processing.plugins.kubernetes.utils import get_pod_volumes
 from task_processing.plugins.kubernetes.utils import get_security_context_for_capabilities
 
@@ -395,7 +397,11 @@ class KubernetesPodExecutor(TaskExecutor):
                 spec=V1PodSpec(
                     restart_policy=task_config.restart_policy,
                     containers=[container],
-                    volumes=get_pod_volumes(task_config.volumes)
+                    volumes=get_pod_volumes(task_config.volumes),
+                    node_selector=dict(task_config.node_selectors),
+                    affinity=V1Affinity(
+                        node_affinity=get_node_affinity(task_config.node_affinities),
+                    )
                 ),
             )
         except Exception:

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -22,8 +22,8 @@ from task_processing.interfaces.event import Event
 from task_processing.interfaces.event import task_event
 from task_processing.plugins.kubernetes.kube_client import KubeClient
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
-from task_processing.plugins.kubernetes.types import KubernetesTaskMetadata
-from task_processing.plugins.kubernetes.types import KubernetesTaskState
+from task_processing.plugins.kubernetes.task_metadata import KubernetesTaskMetadata
+from task_processing.plugins.kubernetes.task_metadata import KubernetesTaskState
 from task_processing.plugins.kubernetes.types import PodEvent
 from task_processing.plugins.kubernetes.utils import get_kubernetes_env_vars
 from task_processing.plugins.kubernetes.utils import get_kubernetes_volume_mounts

--- a/task_processing/plugins/kubernetes/task_metadata.py
+++ b/task_processing/plugins/kubernetes/task_metadata.py
@@ -1,0 +1,35 @@
+from enum import auto
+from enum import unique
+from typing import Tuple
+
+from pyrsistent import field
+from pyrsistent import PRecord
+from pyrsistent import PVector
+from pyrsistent import pvector
+from pyrsistent.typing import PVector as PVectorType
+
+from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
+from task_processing.utils import AutoEnum
+
+
+@unique
+class KubernetesTaskState(AutoEnum):
+    TASK_PENDING = auto()
+    TASK_RUNNING = auto()
+    TASK_FINISHED = auto()
+    TASK_FAILED = auto()
+    TASK_UNKNOWN = auto()
+    TASK_LOST = auto()
+
+
+class KubernetesTaskMetadata(PRecord):
+    # what box this task/Pod was scheduled onto
+    node_name: str = field(type=str, initial='')
+
+    # the config used to launch this task/Pod
+    task_config: KubernetesTaskConfig = field(type=KubernetesTaskConfig, mandatory=True)
+
+    task_state: KubernetesTaskState = field(type=KubernetesTaskState, mandatory=True)
+    # List of state to when that state was entered (stored as a timestamp)
+    task_state_history: PVectorType[Tuple[KubernetesTaskState, float]] = field(
+        type=PVector, factory=pvector, mandatory=True)

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -1,3 +1,4 @@
+import enum
 from typing import Any
 from typing import Dict
 
@@ -16,16 +17,31 @@ class SecretEnvSource(TypedDict):
     key: str
 
 
-class NodeAffinityOperator:
+class EnumSet(enum.EnumMeta):
+    def __contains__(cls, v):
+        try:
+            cls(v)
+        except ValueError:
+            return False
+        else:
+            return True
+
+
+class NodeAffinityOperator(str, enum.Enum, metaclass=EnumSet):
     IN = "In"
     NOT_IN = "NotIn"
     EXISTS = "Exists"
     DOES_NOT_EXIST = "DoesNotExist"
     GT = "Gt"
     LT = "Lt"
-    ALL = {IN, NOT_IN, EXISTS, DOES_NOT_EXIST, GT, LT}
 
 
+# the value depends on operator:
+# - In/NotIn requires a list
+# - Exists/DoesNotExist does not expect a value
+# - Gt/Lt requires an int
+# the value is converted into a list of strings, which is expected by
+# V1NodeSelectorRequirement.
 class NodeAffinity(TypedDict):
     key: str
     operator: str

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -2,7 +2,9 @@ from enum import auto
 from enum import unique
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Tuple
+from typing import Union
 
 from kubernetes.client import V1Pod
 from pyrsistent import field
@@ -25,6 +27,13 @@ class DockerVolume(TypedDict):
 class SecretEnvSource(TypedDict):
     secret_name: str  # full name of k8s secret resource
     key: str
+
+
+# from: https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1NodeSelectorRequirement.md
+class NodeAffinity(TypedDict):
+    key: str
+    operator: str
+    value: Union[List[str], int]
 
 
 class PodEvent(TypedDict):

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -16,7 +16,16 @@ class SecretEnvSource(TypedDict):
     key: str
 
 
-# from: https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1NodeSelectorRequirement.md
+class NodeAffinityOperator:
+    IN = "In"
+    NOT_IN = "NotIn"
+    EXISTS = "Exists"
+    DOES_NOT_EXIST = "DoesNotExist"
+    GT = "Gt"
+    LT = "Lt"
+    ALL = {IN, NOT_IN, EXISTS, DOES_NOT_EXIST, GT, LT}
+
+
 class NodeAffinity(TypedDict):
     key: str
     operator: str

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -1,21 +1,8 @@
-from enum import auto
-from enum import unique
 from typing import Any
 from typing import Dict
-from typing import List
-from typing import Tuple
-from typing import Union
 
 from kubernetes.client import V1Pod
-from pyrsistent import field
-from pyrsistent import PRecord
-from pyrsistent import PVector
-from pyrsistent import pvector
-from pyrsistent.typing import PVector as PVectorType
 from typing_extensions import TypedDict
-
-from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
-from task_processing.utils import AutoEnum
 
 
 class DockerVolume(TypedDict):
@@ -33,7 +20,7 @@ class SecretEnvSource(TypedDict):
 class NodeAffinity(TypedDict):
     key: str
     operator: str
-    value: Union[List[str], int]
+    value: Any
 
 
 class PodEvent(TypedDict):
@@ -44,26 +31,3 @@ class PodEvent(TypedDict):
     object: V1Pod
     # this is just the dict-ified version of object - but it's too big to type here
     raw_object: Dict[str, Any]
-
-
-@unique
-class KubernetesTaskState(AutoEnum):
-    TASK_PENDING = auto()
-    TASK_RUNNING = auto()
-    TASK_FINISHED = auto()
-    TASK_FAILED = auto()
-    TASK_UNKNOWN = auto()
-    TASK_LOST = auto()
-
-
-class KubernetesTaskMetadata(PRecord):
-    # what box this task/Pod was scheduled onto
-    node_name: str = field(type=str, initial='')
-
-    # the config used to launch this task/Pod
-    task_config: KubernetesTaskConfig = field(type=KubernetesTaskConfig, mandatory=True)
-
-    task_state: KubernetesTaskState = field(type=KubernetesTaskState, mandatory=True)
-    # List of state to when that state was entered (stored as a timestamp)
-    task_state_history: PVectorType[Tuple[KubernetesTaskState, float]] = field(
-        type=PVector, factory=pvector, mandatory=True)

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -193,17 +193,37 @@ def test_secret_env_rejects_invalid_specification(secret_environment):
 
 
 @pytest.mark.parametrize(
-    "node_affinity", [
-        {},  # missing required keys
-        {"key": "a_label"},  # missing operator
-        {"key": "a_label", "operator": "Exists"},  # missing value
-        {"key": "a_label", "operator": "BAD", "value": None},  # invalid operator
+    "node_affinity,exc_msg", [
+        ({}, "missing keys"),  # missing required keys
+        ({"key": "a_label"}, "missing keys"),  # missing operator
+        ({"key": "a_label", "operator": "Exists"}, "missing keys"),  # missing value
+        (  # invalid operator
+            {"key": "a_label", "operator": "BAD", "value": None},
+            "got 'BAD', but expected one of",
+        ),
+        (  # non-list value
+            {"key": "a_label", "operator": "In", "value": None},
+            "got non-list value 'None' for affinity operator 'In'",
+        ),
+        (  # non-list value
+            {"key": "a_label", "operator": "NotIn", "value": None},
+            "got non-list value 'None' for affinity operator 'NotIn'",
+        ),
+        (  # non-int value
+            {"key": "a_label", "operator": "Gt", "value": None},
+            "got non-int value 'None' for affinity operator 'Gt'",
+        ),
+        (  # non-int value
+            {"key": "a_label", "operator": "Lt", "value": None},
+            "got non-int value 'None' for affinity operator 'Lt'",
+        ),
     ],
 )
-def test_valid_node_affinities_invalid_affinity(node_affinity):
-    with pytest.raises(InvariantException):
+def test_valid_node_affinities_invalid_affinity(node_affinity, exc_msg):
+    with pytest.raises(InvariantException) as exc:
         KubernetesTaskConfig(
             image="fake_docker_image",
             command="fake_command",
             node_affinities=[node_affinity]
         )
+    assert exc_msg in exc.value.invariant_errors[0]

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -190,3 +190,20 @@ def test_secret_env_rejects_invalid_specification(secret_environment):
             command="fake_command",
             secret_environment=secret_environment
         )
+
+
+@pytest.mark.parametrize(
+    "node_affinity", [
+        {},  # missing required keys
+        {"key": "a_label"},  # missing operator
+        {"key": "a_label", "operator": "Exists"},  # missing value
+        {"key": "a_label", "operator": "BAD", "value": None},  # invalid operator
+    ],
+)
+def test_valid_node_affinities_invalid_affinity(node_affinity):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            image="fake_docker_image",
+            command="fake_command",
+            node_affinities=[node_affinity]
+        )

--- a/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
@@ -224,17 +224,3 @@ def test_get_node_affinity_ok():
 
 def test_get_node_affinity_empty():
     assert get_node_affinity([]) is None
-
-
-@pytest.mark.parametrize(
-    "aff,exc", [
-        (NodeAffinity(key="a_label", operator="In", value=None), TypeError),
-        (NodeAffinity(key="a_label", operator="NotIn", value=None), TypeError),
-        (NodeAffinity(key="a_label", operator="Gt", value=None), TypeError),
-        (NodeAffinity(key="a_label", operator="Lt", value=None), TypeError),
-        (NodeAffinity(key="a_label", operator="BAD", value=None), ValueError),
-    ],
-)
-def test_get_node_affinity_error(aff, exc):
-    with pytest.raises(exc):
-        get_node_affinity(pvector([aff]))

--- a/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
@@ -3,15 +3,22 @@ from kubernetes.client import V1Capabilities
 from kubernetes.client import V1EnvVar
 from kubernetes.client import V1EnvVarSource
 from kubernetes.client import V1HostPathVolumeSource
+from kubernetes.client import V1NodeAffinity
+from kubernetes.client import V1NodeSelector
+from kubernetes.client import V1NodeSelectorRequirement
+from kubernetes.client import V1NodeSelectorTerm
 from kubernetes.client import V1SecretKeySelector
 from kubernetes.client import V1SecurityContext
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
 from pyrsistent import pmap
+from pyrsistent import pvector
 from pyrsistent import v
 
+from task_processing.plugins.kubernetes.types import NodeAffinity
 from task_processing.plugins.kubernetes.utils import get_kubernetes_env_vars
 from task_processing.plugins.kubernetes.utils import get_kubernetes_volume_mounts
+from task_processing.plugins.kubernetes.utils import get_node_affinity
 from task_processing.plugins.kubernetes.utils import get_pod_volumes
 from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 from task_processing.plugins.kubernetes.utils import get_sanitised_volume_name
@@ -173,3 +180,61 @@ def test_get_kubernetes_env_vars():
                                        )
 
     assert sorted(expected_env_vars, key=lambda x: x.name) == sorted(env_vars, key=lambda x: x.name)
+
+
+def test_get_node_affinity_ok():
+    affinities = pvector([
+        NodeAffinity(key="label0", operator="In", value=[1, 2, 3]),
+        NodeAffinity(key="label1", operator="NotIn", value=[3, 2, 1]),
+        NodeAffinity(key="label2", operator="Gt", value=1),
+        NodeAffinity(key="label3", operator="Lt", value=2),
+        NodeAffinity(key="label4", operator="Exists", value="hi"),
+        NodeAffinity(key="label5", operator="DoesNotExist", value="bye"),
+    ])
+
+    assert get_node_affinity(affinities) == V1NodeAffinity(
+        required_during_scheduling_ignored_during_execution=V1NodeSelector(
+            node_selector_terms=[
+                V1NodeSelectorTerm(
+                    match_expressions=[
+                        V1NodeSelectorRequirement(
+                            key="label0", operator="In", values=["1", "2", "3"],
+                        ),
+                        V1NodeSelectorRequirement(
+                            key="label1", operator="NotIn", values=["3", "2", "1"],
+                        ),
+                        V1NodeSelectorRequirement(
+                            key="label2", operator="Gt", values=["1"],
+                        ),
+                        V1NodeSelectorRequirement(
+                            key="label3", operator="Lt", values=["2"],
+                        ),
+                        V1NodeSelectorRequirement(
+                            key="label4", operator="Exists", values=[],
+                        ),
+                        V1NodeSelectorRequirement(
+                            key="label5", operator="DoesNotExist", values=[],
+                        ),
+                    ]
+                )
+            ]
+        )
+    )
+
+
+def test_get_node_affinity_empty():
+    assert get_node_affinity([]) is None
+
+
+@pytest.mark.parametrize(
+    "aff,exc", [
+        (NodeAffinity(key="a_label", operator="In", value=None), TypeError),
+        (NodeAffinity(key="a_label", operator="NotIn", value=None), TypeError),
+        (NodeAffinity(key="a_label", operator="Gt", value=None), TypeError),
+        (NodeAffinity(key="a_label", operator="Lt", value=None), TypeError),
+        (NodeAffinity(key="a_label", operator="BAD", value=None), ValueError),
+    ],
+)
+def test_get_node_affinity_error(aff, exc):
+    with pytest.raises(exc):
+        get_node_affinity(pvector([aff]))


### PR DESCRIPTION
### Description
This PR adds node selectors and affinities to the k8s task config, and makes the pod executor use them. Couple of things:

- By default, it does not add any selectors or affinities. If we want to set, say, a default selector for the default pool, that should be set upstream.
- In soa-configs, node selectors and affinities are exposed to users as just node selectors. In task_processing, they are kept separate. The assumption is that the soa-configs interface has already been transpiled to selectors and affinities upstream.
- I moved the task metadata stuff to its own file because it was royally screwing with typing imports.

### Testing
`make test`

### Notes
no real-world test yet, but i am reasonably confident this works, since this is exactly how paasta does it. ill still do a test before merging, but the PR is in a reviewable state