### PR TITLE
Fix typo in KubeClient.get_pod

### DIFF
--- a/task_processing/plugins/kubernetes/kube_client.py
+++ b/task_processing/plugins/kubernetes/kube_client.py
@@ -168,7 +168,7 @@ class KubeClient:
         while attempts:
             try:
                 pod = self.core.read_namespaced_pod(
-                    namespace=namespace, name={pod_name},
+                    namespace=namespace, name=pod_name,
                 )
                 return pod
             except ApiException as e:

--- a/tests/unit/plugins/kubernetes/kube_client_test.py
+++ b/tests/unit/plugins/kubernetes/kube_client_test.py
@@ -108,7 +108,6 @@ def test_KubeClient_get_pod():
         mock_kube_client.CoreV1Api().read_namespaced_pod.return_value = mock.Mock()
         client = KubeClient(kubeconfig_path=mock_config_path)
         client.get_pod(namespace='ns', pod_name='pod-name', attempts=1)
-    assert mock_kube_client.CoreV1Api().read_namespaced_pod.call_count == 1
-    mock_kube_client.CoreV1Api().read_namespaced_pod.assert_called_with(
+    mock_kube_client.CoreV1Api().read_namespaced_pod.assert_called_once_with(
         namespace='ns', name='pod-name'
     )

--- a/tests/unit/plugins/kubernetes/kube_client_test.py
+++ b/tests/unit/plugins/kubernetes/kube_client_test.py
@@ -92,3 +92,23 @@ def test_KubeClient_get_pod_unknown_exception():
         mock_kube_client.CoreV1Api().read_namespaced_pod.side_effect = [Exception]
         client = KubeClient(kubeconfig_path=mock_config_path)
         client.get_pod(namespace='ns', pod_name='pod-name', attempts=2)
+
+
+def test_KubeClient_get_pod():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client, mock.patch.dict(
+        os.environ, {"KUBECONFIG": "/another/kube/config.conf"}
+    ):
+        mock_config_path = "/OVERRIDE.conf"
+        mock_kube_client.CoreV1Api().read_namespaced_pod.return_value = mock.Mock()
+        client = KubeClient(kubeconfig_path=mock_config_path)
+        client.get_pod(namespace='ns', pod_name='pod-name', attempts=1)
+    assert mock_kube_client.CoreV1Api().read_namespaced_pod.call_count == 1
+    mock_kube_client.CoreV1Api().read_namespaced_pod.assert_called_with(
+        namespace='ns', name='pod-name'
+    )


### PR DESCRIPTION
When I added `KubeClient.get_pod` in #175, instead of passing an f-string of the pod name, I passed a set of `{pod_name}` to `read_namespaced_pod`.

This also exposed that there was no validation that we were calling `read_namespaced_pod` with correct arguments, so I added a test for this, which would have caught this typo earlier.
```
E       AssertionError: Expected call: read_namespaced_pod(name='pod-name', namespace='ns')
E       Actual call: read_namespaced_pod(name={'pod-name'}, namespace='ns')
```