### PR TITLE
Allow node affinity values to be wrapped in tuples

### DIFF
--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -152,7 +152,7 @@ def _valid_node_affinities(affinities: Sequence["NodeAffinity"]) -> Tuple[bool, 
 
         elif (
             op in {NodeAffinityOperator.IN, NodeAffinityOperator.NOT_IN} and
-            type(val) != list
+            type(val) not in {list, tuple}
         ):
             return (
                 False,


### PR DESCRIPTION
The way that Tron config works, lists often get turned into tuples. The
k8s clientlib doesn't seem to mind that it's getting tuples here, so we
might as well allow them to be passed in in the first place so that our
users (or us in Tron) don't need to care about tuples vs lists in the
first place here.