### PR TITLE
Hardcode the DNSPolicy for Pods to Default

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -401,7 +401,12 @@ class KubernetesPodExecutor(TaskExecutor):
                     node_selector=dict(task_config.node_selectors),
                     affinity=V1Affinity(
                         node_affinity=get_node_affinity(task_config.node_affinities),
-                    )
+                    ),
+                    # we're hardcoding this as Default as this is what we generally use
+                    # internally - until we have a usecase for something that needs one
+                    # of the other DNS policies, we can probably punt on plumbing all the
+                    # bits for making this configurable
+                    dns_policy="Default",
                 ),
             )
         except Exception:

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -146,6 +146,7 @@ def test_run(mock_get_node_affinity, k8s_executor):
             )],
             node_selector={"hello": "world"},
             affinity=V1Affinity(node_affinity=mock_get_node_affinity.return_value),
+            dns_policy="Default",
         ),
     )
 


### PR DESCRIPTION
This is what is recommended by our internal security team, so let's just
hardcode for now since we *shouldn't* really need any of the other
policies.