### PR TITLE
Support setting Pod labels

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -392,7 +392,8 @@ class KubernetesPodExecutor(TaskExecutor):
             pod = V1Pod(
                 metadata=V1ObjectMeta(
                     name=task_config.pod_name,
-                    namespace=self.namespace
+                    namespace=self.namespace,
+                    labels=dict(task_config.labels),
                 ),
                 spec=V1PodSpec(
                     restart_policy=task_config.restart_policy,

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -265,6 +265,11 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         factory=pvector,
         invariant=_valid_node_affinities,
     )
+    labels = field(
+        type=PMap if not TYPE_CHECKING else PMap[str, str],
+        initial=m(),
+        factory=pmap,
+    )
 
     @property
     def pod_name(self) -> str:

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -109,6 +109,9 @@ def test_run(mock_get_node_affinity, k8s_executor):
         volumes=[{"host_path": "/a", "container_path": "/b", "mode": "RO"}],
         node_selectors={"hello": "world"},
         node_affinities=[dict(key="a_label", operator="In", value=[])],
+        labels={
+            "some_label": "some_label_value",
+        }
     )
     expected_container = V1Container(
         image=task_config.image,
@@ -135,7 +138,10 @@ def test_run(mock_get_node_affinity, k8s_executor):
     expected_pod = V1Pod(
         metadata=V1ObjectMeta(
             name=task_config.pod_name,
-            namespace="task_processing_tests"
+            namespace="task_processing_tests",
+            labels={
+                "some_label": "some_label_value",
+            },
         ),
         spec=V1PodSpec(
             restart_policy=task_config.restart_policy,


### PR DESCRIPTION
We'll need this to adhere to the PaaSTA Workload Contract (and allow
tooling like OPA to work with our Pods)