### PR TITLE
Support setting Pod annotations

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -424,6 +424,7 @@ class KubernetesPodExecutor(TaskExecutor):
                     name=task_config.pod_name,
                     namespace=self.namespace,
                     labels=dict(task_config.labels),
+                    annotations=dict(task_config.annotations),
                 ),
                 spec=V1PodSpec(
                     restart_policy=task_config.restart_policy,

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -268,6 +268,11 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         initial=m(),
         factory=pmap,
     )
+    annotations = field(
+        type=PMap if not TYPE_CHECKING else PMap[str, str],
+        initial=m(),
+        factory=pmap,
+    )
     fs_group = field(
         type=int,
         # this is the `nobody` user at Yelp, which is what we should always be using

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -112,7 +112,10 @@ def test_run(mock_get_node_affinity, k8s_executor):
         node_affinities=[dict(key="a_label", operator="In", value=[])],
         labels={
             "some_label": "some_label_value",
-        }
+        },
+        annotations={
+            "paasta.yelp.com/some_annotation": "some_value",
+        },
     )
     expected_container = V1Container(
         image=task_config.image,
@@ -142,6 +145,9 @@ def test_run(mock_get_node_affinity, k8s_executor):
             namespace="task_processing_tests",
             labels={
                 "some_label": "some_label_value",
+            },
+            annotations={
+                "paasta.yelp.com/some_annotation": "some_value",
             },
         ),
         spec=V1PodSpec(


### PR DESCRIPTION
We'll use this for toggling certain behaviours (e.g., whether
or not Pods should get a routable IP internally)