### PR TITLE
Add Service Account support

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -442,7 +442,8 @@ class KubernetesPodExecutor(TaskExecutor):
                     share_process_namespace=True,
                     security_context=V1PodSecurityContext(
                         fs_group=task_config.fs_group,
-                    )
+                    ),
+                    service_account_name=task_config.service_account_name,
                 ),
             )
         except Exception:

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -33,7 +33,7 @@ POD_SUFFIX_LENGTH = 6
 # but let's give ourselves a little buffer so we'll round down a bit
 MAX_POD_NAME_LENGTH = 150
 MAX_DNS_SUBDOMAIN_NAME_LENGTH = 253
-VALID_DNS_SUBDOMAIN_NAME_REGEX = '[a-z0-9]([.-a-z0-9]*[a-z0-9])?'
+VALID_DNS_SUBDOMAIN_NAME_REGEX = '^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$'
 VALID_VOLUME_KEYS = {'mode', 'container_path', 'host_path'}
 VALID_SECRET_ENV_KEYS = {'secret_name', 'key'}
 VALID_CAPABILITIES = {

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -116,6 +116,7 @@ def test_run(mock_get_node_affinity, k8s_executor):
         annotations={
             "paasta.yelp.com/some_annotation": "some_value",
         },
+        service_account_name="test_sa",
     )
     expected_container = V1Container(
         image=task_config.image,
@@ -164,6 +165,7 @@ def test_run(mock_get_node_affinity, k8s_executor):
             node_selector={"hello": "world"},
             affinity=V1Affinity(node_affinity=mock_get_node_affinity.return_value),
             dns_policy="Default",
+            service_account_name=task_config.service_account_name,
         ),
     )
 

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -116,7 +116,7 @@ def test_run(mock_get_node_affinity, k8s_executor):
         annotations={
             "paasta.yelp.com/some_annotation": "some_value",
         },
-        service_account_name="test_sa",
+        service_account_name="testsa",
     )
     expected_container = V1Container(
         image=task_config.image,

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -228,3 +228,36 @@ def test_valid_node_affinities_invalid_affinity(node_affinity, exc_msg):
             node_affinities=[node_affinity]
         )
     assert exc_msg in exc.value.invariant_errors[0]
+
+
+@pytest.mark.parametrize(
+    "service_account_name", (
+        "",
+        "F" * 300,
+    )
+)
+def test_service_account_name_invariant(service_account_name):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="fake_task_name",
+            uuid="fake_id",
+            image="fake_docker_image",
+            command="fake_command",
+            service_account_name=service_account_name,
+        )
+
+
+@pytest.mark.parametrize(
+    "service_account_name", (
+        None,
+        "yay",
+    )
+)
+def test_service_account_name_invariant_success(service_account_name):
+    KubernetesTaskConfig(
+        name="fake_task_name",
+        uuid="fake_id",
+        image="fake_docker_image",
+        command="fake_command",
+        service_account_name=service_account_name,
+    )

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -7,8 +7,8 @@ from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 
 def test_kubernetes_task_config_set_pod_name():
     task_config = KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
+        name="fake--task--name",
+        uuid="fake--id",
         image="fake_docker_image",
         command="fake_command"
     )
@@ -19,8 +19,8 @@ def test_kubernetes_task_config_set_pod_name():
 
 def test_kubernetes_task_config_set_pod_name_truncates_long_name():
     task_config = KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
+        name="fake--task--name",
+        uuid="fake--id",
         image="fake_docker_image",
         command="fake_command"
     )
@@ -32,8 +32,8 @@ def test_kubernetes_task_config_set_pod_name_truncates_long_name():
 
 def test_kubernetes_task_config_enforces_command_requirmenets():
     task_config = KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
+        name="fake--task--name",
+        uuid="fake--id",
         image="fake_docker_image",
         command="fake_command"
     )
@@ -50,8 +50,8 @@ def test_kubernetes_task_config_enforces_command_requirmenets():
 def test_cap_add_capabilities_rejects_invalid_capabilites(capabilties):
     with pytest.raises(InvariantException):
         KubernetesTaskConfig(
-            name="fake_task_name",
-            uuid="fake_id",
+            name="fake--task--name",
+            uuid="fake--id",
             image="fake_docker_image",
             command="fake_command",
             cap_add=capabilties,
@@ -66,8 +66,8 @@ def test_cap_add_capabilities_rejects_invalid_capabilites(capabilties):
 )
 def test_cap_add_capabilities_valid_capabilites(capabilties):
     task_config = KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
+        name="fake--task--name",
+        uuid="fake--id",
         image="fake_docker_image",
         command="fake_command",
         cap_add=capabilties,
@@ -84,8 +84,8 @@ def test_cap_add_capabilities_valid_capabilites(capabilties):
 def test_cap_drop_capabilities_rejects_invalid_capabilites(capabilties):
     with pytest.raises(InvariantException):
         KubernetesTaskConfig(
-            name="fake_task_name",
-            uuid="fake_id",
+            name="fake--task--name",
+            uuid="fake--id",
             image="fake_docker_image",
             command="fake_command",
             cap_drop=capabilties,
@@ -100,8 +100,8 @@ def test_cap_drop_capabilities_rejects_invalid_capabilites(capabilties):
 )
 def test_cap_drop_capabilities_valid_capabilites(capabilties):
     task_config = KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
+        name="fake--task--name",
+        uuid="fake--id",
         image="fake_docker_image",
         command="fake_command",
         cap_drop=capabilties,
@@ -124,8 +124,8 @@ def test_cap_drop_capabilities_valid_capabilites(capabilties):
 def test_volume_rejects_invalid_specification(volumes):
     with pytest.raises(InvariantException):
         KubernetesTaskConfig(
-            name="fake_task_name",
-            uuid="fake_id",
+            name="fake--task--name",
+            uuid="fake--id",
             image="fake_docker_image",
             command="fake_command",
             volumes=volumes
@@ -143,8 +143,8 @@ def test_volume_rejects_invalid_specification(volumes):
 )
 def test_volume_valid_specification(volumes):
     task_config = KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
+        name="fake--task--name",
+        uuid="fake--id",
         image="fake_docker_image",
         command="fake_command",
         volumes=volumes
@@ -164,8 +164,8 @@ def test_volume_valid_specification(volumes):
 )
 def test_secret_env_valid_specification(secret_environment):
     task_config = KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
+        name="fake--task--name",
+        uuid="fake--id",
         image="fake_docker_image",
         command="fake_command",
         secret_environment=secret_environment
@@ -185,8 +185,8 @@ def test_secret_env_valid_specification(secret_environment):
 def test_secret_env_rejects_invalid_specification(secret_environment):
     with pytest.raises(InvariantException):
         KubernetesTaskConfig(
-            name="fake_task_name",
-            uuid="fake_id",
+            name="fake--task--name",
+            uuid="fake--id",
             image="fake_docker_image",
             command="fake_command",
             secret_environment=secret_environment
@@ -234,13 +234,14 @@ def test_valid_node_affinities_invalid_affinity(node_affinity, exc_msg):
     "service_account_name", (
         "",
         "F" * 300,
+        "bad_name",
     )
 )
 def test_service_account_name_invariant(service_account_name):
     with pytest.raises(InvariantException):
         KubernetesTaskConfig(
-            name="fake_task_name",
-            uuid="fake_id",
+            name="fake--task--name",
+            uuid="fake--id",
             image="fake_docker_image",
             command="fake_command",
             service_account_name=service_account_name,
@@ -255,8 +256,8 @@ def test_service_account_name_invariant(service_account_name):
 )
 def test_service_account_name_invariant_success(service_account_name):
     KubernetesTaskConfig(
-        name="fake_task_name",
-        uuid="fake_id",
+        name="fake--task--name",
+        uuid="fake--id",
         image="fake_docker_image",
         command="fake_command",
         service_account_name=service_account_name,


### PR DESCRIPTION
We'll use this for Pod Identity - there's a webhook that will inject
a secret token + some environment variables if a Pod has a Service
Account set up.