### PR TITLE
Add support for file-based secrets

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -32,9 +32,11 @@ from task_processing.plugins.kubernetes.types import PodEvent
 from task_processing.plugins.kubernetes.utils import get_capabilities_for_capability_changes
 from task_processing.plugins.kubernetes.utils import get_kubernetes_empty_volume_mounts
 from task_processing.plugins.kubernetes.utils import get_kubernetes_env_vars
+from task_processing.plugins.kubernetes.utils import get_kubernetes_secret_volume_mounts
 from task_processing.plugins.kubernetes.utils import get_kubernetes_volume_mounts
 from task_processing.plugins.kubernetes.utils import get_node_affinity
 from task_processing.plugins.kubernetes.utils import get_pod_empty_volumes
+from task_processing.plugins.kubernetes.utils import get_pod_secret_volumes
 from task_processing.plugins.kubernetes.utils import get_pod_volumes
 from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 
@@ -428,6 +430,7 @@ class KubernetesPodExecutor(TaskExecutor):
         volume_mounts = (
             get_kubernetes_volume_mounts(task_config.volumes)
             + get_kubernetes_empty_volume_mounts(task_config.empty_volumes)
+            + get_kubernetes_secret_volume_mounts(task_config.secret_volumes)
         )
 
         capabilities = get_capabilities_for_capability_changes(
@@ -492,6 +495,7 @@ class KubernetesPodExecutor(TaskExecutor):
             volumes = (
                 get_pod_volumes(task_config.volumes)
                 + get_pod_empty_volumes(task_config.empty_volumes)
+                + get_pod_secret_volumes(task_config.secret_volumes)
             )
 
             pod = V1Pod(

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -1,6 +1,7 @@
 import enum
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 
 from kubernetes.client import V1Pod
@@ -17,6 +18,20 @@ class EmptyVolume(TypedDict):
     container_path: str
     medium: Optional[str]  # XXX: Optional[Literal["Memory"]] In this case
     size: Optional[str]  # XXX: implement a validator for this
+
+
+class SecretVolumeItem(TypedDict):
+    key: str
+    path: str
+    mode: Optional[str]  # octal permissions mode
+
+
+class SecretVolume(TypedDict):
+    secret_volume_name: str
+    secret_name: str
+    container_path: str
+    default_mode: Optional[str]  # octal permissions mode
+    items: List[SecretVolumeItem]
 
 
 class SecretEnvSource(TypedDict):

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -192,6 +192,105 @@ def test_volume_valid_specification(volumes):
 
 
 @pytest.mark.parametrize(
+    "volumes", (
+        # missing required keys
+        [{"host_path": "/a"}],
+        [{"containerPath": "/b"}],
+        [
+            {
+                "container_path": "/b",
+                "secret_volume_name": "secretvolumename",
+                "secret_name": "secret",
+                # non-str mode
+                "default_mode": 755,
+                "items": None,
+            },
+        ],
+        [
+            {
+                "container_path": "/b",
+                "secret_volume_name": "secretvolumename",
+                "secret_name": "secret",
+                "default_mode": "755",
+                "items": None,
+            },
+            {
+                "container_path": "/b",
+                "secret_volume_name": "secretvolumename",
+                "secret_name": "secret",
+                # non-str mode
+                "default_mode": 755,
+                "items": None,
+            },
+        ],
+        [
+            {
+                "container_path": "/b",
+                "secret_volume_name": "secretvolumename",
+                "secret_name": "secret",
+                "default_mode": "755",
+                "items": [
+                    {
+                        "key": "key",
+                        "path": "path",
+                        # non-str mode
+                        "mode": 755,
+                    }
+                ],
+            },
+        ],
+    )
+)
+def test_secret_volume_rejects_invalid_specification(volumes):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="fake--task--name",
+            uuid="fake--id",
+            image="fake_docker_image",
+            command="fake_command",
+            secret_volumes=volumes
+        )
+
+
+@pytest.mark.parametrize(
+    "volumes", (
+        (
+            {
+                "container_path": "/b",
+                "secret_volume_name": "secretvolumename",
+                "secret_name": "secret",
+                "default_mode": "755",
+                "items": None,
+            },
+            {
+                "container_path": "/b",
+                "secret_volume_name": "secretvolumename",
+                "secret_name": "secret",
+                "default_mode": "755",
+                "items": [
+                    {
+                        "key": "key",
+                        "path": "path",
+                        "mode": "755",
+                    }
+                ],
+            },
+        ),
+    )
+)
+def test_secret_volume_valid_specification(volumes):
+    task_config = KubernetesTaskConfig(
+        name="fake--task--name",
+        uuid="fake--id",
+        image="fake_docker_image",
+        command="fake_command",
+        secret_volumes=volumes
+    )
+
+    assert tuple(task_config.secret_volumes) == volumes
+
+
+@pytest.mark.parametrize(
     "empty_volumes", (
         ({"medium": None},),
         ({"medium": "Memory"},),


### PR DESCRIPTION
For PaaSTA services, we have support for mounting Kubernetes Secrets as
files directly - this adds similar support for anything launched by
task_processing.

For Tron usage, we're expecting paasta-tools to deal with formatting all
the information that we need here and pass it to Tron (which will then
just wrap it in a KubernetesTaskConfig)