### PR TITLE
Enable setting env vars using field selectors

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -414,8 +414,9 @@ class KubernetesPodExecutor(TaskExecutor):
                     }
                 ),
                 env=get_kubernetes_env_vars(
-                    task_config.environment,
-                    task_config.secret_environment,
+                    environment=task_config.environment,
+                    secret_environment=task_config.secret_environment,
+                    field_selector_environment=task_config.field_selector_environment,
                 ),
                 volume_mounts=get_kubernetes_volume_mounts(task_config.volumes)
             )

--- a/task_processing/plugins/kubernetes/types.py
+++ b/task_processing/plugins/kubernetes/types.py
@@ -17,6 +17,10 @@ class SecretEnvSource(TypedDict):
     key: str
 
 
+class ObjectFieldSelectorSource(TypedDict):
+    field_path: str  # full field path - e.g., status.podIP
+
+
 class EnumSet(enum.EnumMeta):
     def __contains__(cls, v):
         try:

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -194,6 +194,47 @@ def test_secret_env_rejects_invalid_specification(secret_environment):
 
 
 @pytest.mark.parametrize(
+    "field_selector_environment", (
+        pmap({'PAASTA_POD_IP': {"field_path": "status.podIP"}}),
+        pmap({
+            'PAASTA_POD_IP': {"field_path": "status.podIP"},
+            'PAASTA_HOST': {"field_path": "spec.nodeName"},
+        }),
+    )
+)
+def test_field_selector_env_valid_specification(field_selector_environment):
+    task_config = KubernetesTaskConfig(
+        name="fake--task--name",
+        uuid="fake--id",
+        image="fake_docker_image",
+        command="fake_command",
+        field_selector_environment=field_selector_environment
+    )
+
+    assert task_config.field_selector_environment == field_selector_environment
+
+
+@pytest.mark.parametrize(
+    "field_selector_environment", (
+        pmap({'PAASTA_POD_IP': {}}),
+        pmap({
+            'PAASTA_POD_IP': {"path": "status.podIP"},
+            'PAASTA_HOST': {"field_path": "spec.nodeName"},
+        }),
+    )
+)
+def test_field_selector_env_rejects_invalid_specification(field_selector_environment):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="fake--task--name",
+            uuid="fake--id",
+            image="fake_docker_image",
+            command="fake_command",
+            field_selector_environment=field_selector_environment
+        )
+
+
+@pytest.mark.parametrize(
     "node_affinity,exc_msg", [
         ({}, "missing keys"),  # missing required keys
         ({"key": "a_label"}, "missing keys"),  # missing operator


### PR DESCRIPTION
These are needed for our Spark work as well as for fulfilling the PaaSTA
workload contract