### PR TITLE
Use versioned get-pip for OSS Dockerfile

### DIFF
--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -q && \
 
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.6 python3.6-dev python3.6-venv
-RUN wget https://bootstrap.pypa.io/get-pip.py
+RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py
 RUN python3.6 get-pip.py
 RUN ln -s /usr/bin/python3.6 /usr/local/bin/python3
 


### PR DESCRIPTION
pypa.io now serves a get-pip that requires a newer python than what we
test with by default - unless you specify a versioned path