### PR TITLE
Specify other containers to run

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -32,6 +32,7 @@ from task_processing.plugins.kubernetes.utils import get_kubernetes_env_vars
 from task_processing.plugins.kubernetes.utils import get_kubernetes_volume_mounts
 from task_processing.plugins.kubernetes.utils import get_node_affinity
 from task_processing.plugins.kubernetes.utils import get_pod_volumes
+from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 from task_processing.plugins.kubernetes.utils import get_security_context_for_capabilities
 
 logger = logging.getLogger(__name__)
@@ -431,7 +432,10 @@ class KubernetesPodExecutor(TaskExecutor):
             containers = [self._create_container_definition("main", task_config)]
 
             for name, nested_config in task_config.extra_containers.items():
-                containers.append(self._create_container_definition(name, nested_config))
+                containers.append(self._create_container_definition(
+                    get_sanitised_kubernetes_name(name),
+                    nested_config,
+                ))
 
             pod = V1Pod(
                 metadata=V1ObjectMeta(

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -433,7 +433,7 @@ class KubernetesPodExecutor(TaskExecutor):
 
             for name, nested_config in task_config.extra_containers.items():
                 containers.append(self._create_container_definition(
-                    get_sanitised_kubernetes_name(name),
+                    get_sanitised_kubernetes_name(name, length_limit=63),
                     nested_config,
                 ))
 

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -254,6 +254,12 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         invariant=_valid_volumes,
     )
 
+    extra_containers = field(
+        type=PMap if not TYPE_CHECKING else PMap[str, "KubernetesTaskConfig"],
+        initial=m(),
+        factory=pmap,
+    )
+
     cpus = field(
         type=float,
         initial=0.1,

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -258,6 +258,10 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         type=PMap if not TYPE_CHECKING else PMap[str, "KubernetesTaskConfig"],
         initial=m(),
         factory=pmap,
+        invariant=lambda containers: (
+            not any([container.extra_containers for container in containers.values()]),
+            'extra_containers cannot have extra_containers',
+        ),
     )
 
     cpus = field(

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -1,6 +1,7 @@
 import re
 import secrets
 import string
+from itertools import chain
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
@@ -223,9 +224,14 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         valid_length = len(self.pod_name) <= MAX_POD_NAME_LENGTH
         valid_name = bool(re.match(VALID_DNS_SUBDOMAIN_NAME_REGEX, self.pod_name))
 
+        all_ports = list(chain.from_iterable(
+            [self.ports] + [container.ports for container in self.extra_containers.values()]))
+        duplicate_ports = bool(len(set(all_ports)) == len(all_ports))
+
         return (
             (valid_length, f'Pod name must have up to {MAX_POD_NAME_LENGTH} characters.'),
             (valid_name, 'Must comply with Kubernetes pod naming standards.'),
+            (duplicate_ports, 'Containers must define unique ports.'),
         )
 
     uuid = field(type=str, initial=_generate_pod_suffix)  # type: ignore

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -30,7 +30,7 @@ def test_kubernetes_task_config_set_pod_name_truncates_long_name():
     assert task_config.pod_name != "a" * 1000
 
 
-def test_kubernetes_task_config_enforces_command_requirments():
+def test_kubernetes_task_config_enforces_command_requirements():
     task_config = KubernetesTaskConfig(
         name="fake--task--name",
         uuid="fake--id",

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -62,6 +62,23 @@ def test_kubernetes_task_config_no_nested_containers():
         )
 
 
+def test_kubernetes_task_config_no_duplicate_ports():
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="myname",
+            image="myimage",
+            command="mycommand",
+            ports=[1000],
+            extra_containers={
+                "second": KubernetesTaskConfig(
+                    image="myimage",
+                    command="myothercommand",
+                    ports=[1000],
+                ),
+            },
+        )
+
+
 @pytest.mark.parametrize(
     "capabilties", (
         ("NOT_A_CAP",),

--- a/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_task_config_test.py
@@ -30,7 +30,7 @@ def test_kubernetes_task_config_set_pod_name_truncates_long_name():
     assert task_config.pod_name != "a" * 1000
 
 
-def test_kubernetes_task_config_enforces_command_requirmenets():
+def test_kubernetes_task_config_enforces_command_requirments():
     task_config = KubernetesTaskConfig(
         name="fake--task--name",
         uuid="fake--id",
@@ -39,6 +39,27 @@ def test_kubernetes_task_config_enforces_command_requirmenets():
     )
     with pytest.raises(InvariantException):
         task_config.set(command="")
+
+
+def test_kubernetes_task_config_no_nested_containers():
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="myname",
+            image="myimage",
+            command="mycommand",
+            extra_containers={
+                "second": KubernetesTaskConfig(
+                    image="myimage",
+                    command="myothercommand",
+                    extra_containers={
+                        "third": KubernetesTaskConfig(
+                            image="myimage",
+                            command="mythirdcommand",
+                        ),
+                    },
+                ),
+            },
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Allow the user to run more than one container in the pod for a task. Since the pod and container configuration is pretty much all flattened in KubernetesTaskConfig, I've made additional containers addable by nesting KubernetesTaskConfig itself. Of course, none of the pod-level configuration will ever get applied in a nested KubernetesTaskConfig, and nesting more isn't supported (actually checked against). 

Right now, common environment/volume configs would have to be duplicated at the caller. I am not sure if doing something like automatically applying such configs from the main task config would make much sense (I think it would be a bit surprising). 

Another note is that the main container is still called "main", but containers specified via extra_containers need to be given a name via the keys of extra_containers.