### PR TITLE
Permit passing through V1SecurityContext.privileged

### DIFF
--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -333,6 +333,10 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         factory=pvector,
         invariant=_valid_capabilities,
     )
+    privileged = field(
+        type=(bool, type(None)),
+        initial=None,
+    )
     node_selectors = field(
         type=PMap if not TYPE_CHECKING else PMap[str, str],
         initial=m(),

--- a/task_processing/plugins/kubernetes/utils.py
+++ b/task_processing/plugins/kubernetes/utils.py
@@ -16,7 +16,6 @@ from kubernetes.client import V1NodeSelectorRequirement
 from kubernetes.client import V1NodeSelectorTerm
 from kubernetes.client import V1ObjectFieldSelector
 from kubernetes.client import V1SecretKeySelector
-from kubernetes.client import V1SecurityContext
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
 from pyrsistent.typing import PMap
@@ -33,10 +32,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_security_context_for_capabilities(
+def get_capabilities_for_capability_changes(
     cap_add: PVector[str],
     cap_drop: PVector[str],
-) -> Optional[V1SecurityContext]:
+) -> Optional[V1Capabilities]:
     """
     Helper to take lists of capabilties to add/drop and turn them into the
     corresponding Kubernetes representation.
@@ -48,10 +47,10 @@ def get_security_context_for_capabilities(
         if capabilities
     }
     if caps:
-        return V1SecurityContext(capabilities=V1Capabilities(**caps))
+        return V1Capabilities(**caps)
 
     logger.info(
-        "No capabilities found, not creating a security context"
+        "No capabilities found, not creating a capabilities object"
     )
     return None
 

--- a/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
@@ -10,7 +10,6 @@ from kubernetes.client import V1NodeSelectorRequirement
 from kubernetes.client import V1NodeSelectorTerm
 from kubernetes.client import V1ObjectFieldSelector
 from kubernetes.client import V1SecretKeySelector
-from kubernetes.client import V1SecurityContext
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
 from pyrsistent import pmap
@@ -18,6 +17,7 @@ from pyrsistent import pvector
 from pyrsistent import v
 
 from task_processing.plugins.kubernetes.types import NodeAffinity
+from task_processing.plugins.kubernetes.utils import get_capabilities_for_capability_changes
 from task_processing.plugins.kubernetes.utils import get_kubernetes_empty_volume_mounts
 from task_processing.plugins.kubernetes.utils import get_kubernetes_env_vars
 from task_processing.plugins.kubernetes.utils import get_kubernetes_volume_mounts
@@ -26,20 +26,19 @@ from task_processing.plugins.kubernetes.utils import get_pod_empty_volumes
 from task_processing.plugins.kubernetes.utils import get_pod_volumes
 from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 from task_processing.plugins.kubernetes.utils import get_sanitised_volume_name
-from task_processing.plugins.kubernetes.utils import get_security_context_for_capabilities
 
 
 @pytest.mark.parametrize(
     "cap_add,cap_drop,expected", (
         (v(), v(), None),
-        (v("AUDIT_READ"), v(), V1SecurityContext(capabilities=V1Capabilities(add=["AUDIT_READ"]))),
-        (v(), v("AUDIT_READ"), V1SecurityContext(capabilities=V1Capabilities(drop=["AUDIT_READ"]))),
-        (v("AUDIT_WRITE"), v("AUDIT_READ"), V1SecurityContext(
-            capabilities=V1Capabilities(add=["AUDIT_WRITE"], drop=["AUDIT_READ"]))),
+        (v("AUDIT_READ"), v(), V1Capabilities(add=["AUDIT_READ"])),
+        (v(), v("AUDIT_READ"), V1Capabilities(drop=["AUDIT_READ"])),
+        (v("AUDIT_WRITE"), v("AUDIT_READ"), V1Capabilities(
+            add=["AUDIT_WRITE"], drop=["AUDIT_READ"])),
     )
 )
-def test_get_security_context_for_capabilities(cap_add, cap_drop, expected):
-    assert get_security_context_for_capabilities(cap_add, cap_drop) == expected
+def test_get_capabilities_for_capability_changes(cap_add, cap_drop, expected):
+    assert get_capabilities_for_capability_changes(cap_add, cap_drop) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Permit passing through `privileged` for V1SecurityContext. There exists a need to run a container image, [whose documentation insists it be run --privileged](https://github.com/docker-library/docs/tree/master/docker#start-a-daemon-instance).

We already support cap_add and cap_drop, but privileged also [does a bunch of other things, probably the most important of which looks to be mounting cgroupfs rw](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/moby/moby%24%40v20.10.17+HostConfig.Privileged&patternType=literal)