### PR TITLE
Upgrades venv and tests to python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       # GHA won't setup tox for us and we use tox-pip-extensions for venv-update
       - run: pip install tox==3.2 tox-pip-extensions==1.3.0
       - run: make ${{ matrix.make_target }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       # GHA won't setup tox for us and we use tox-pip-extensions for venv-update
       - run: pip install tox==3.2 tox-pip-extensions==1.3.0
       - run: make ${{ matrix.make_target }}
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       # GHA won't setup tox for us and we use tox-pip-extensions for venv-update
       # and we need wheel for actually building wheels :p
       - run: pip install tox==3.2 tox-pip-extensions==1.3.0 wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,48 +1,33 @@
+default_language_version:
+    python: python3
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks.git
-      rev: v2.0.0
-      hooks:
-          - id: trailing-whitespace
-            language_version: python3.8
-          - id: end-of-file-fixer
-            language_version: python3.8
-          - id: check-json
-            files: \.(jshintrc|json)$
-            language_version: python3.8
-          - id: check-yaml
-            language_version: python3.8
-          - id: debug-statements
-            language_version: python3.8
-          - id: name-tests-test
-            files: ^tests/.+\.py$
-            language_version: python3.8
-          - id: flake8
-            language_version: python3.8
-          - id: requirements-txt-fixer
-            language_version: python3.8
-          - id: check-added-large-files
-            language_version: python3.8
-          - id: check-byte-order-marker
-            language_version: python3.8
-          - id: fix-encoding-pragma
-            language_version: python3.8
-            args: [--remove]
-    - repo: https://github.com/asottile/reorder_python_imports.git
-      rev: v1.3.3
-      hooks:
-          - id: reorder-python-imports
-            language_version: python3.8
-            args:
-                [
-                    --remove-import,
-                    "from __future__ import absolute_import",
-                    --remove-import,
-                    "from __future__ import print_function",
-                    --remove-import,
-                    "from __future__ import unicode_literals",
-                ]
-    - repo: https://github.com/pre-commit/mirrors-autopep8
-      rev: v1.4.2
-      hooks:
-          - id: autopep8
-            language_version: python3.8
+-   repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v2.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-json
+        files: \.(jshintrc|json)$
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: name-tests-test
+        files: ^tests/.+\.py$
+    -   id: flake8
+    -   id: requirements-txt-fixer
+    -   id: check-added-large-files
+    -   id: check-byte-order-marker
+    -   id: fix-encoding-pragma
+        args: [--remove]
+-   repo: https://github.com/asottile/reorder_python_imports.git
+    rev: v1.3.3
+    hooks:
+    -   id: reorder-python-imports
+        args: [
+            --remove-import, 'from __future__ import absolute_import',
+            --remove-import, 'from __future__ import print_function',
+            --remove-import, 'from __future__ import unicode_literals',
+        ]
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.2
+    hooks:
+    -   id: autopep8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,44 +1,48 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks.git
-    rev: v2.0.0
-    hooks:
-    -   id: trailing-whitespace
-        language_version: python3.6
-    -   id: end-of-file-fixer
-        language_version: python3.6
-    -   id: check-json
-        files: \.(jshintrc|json)$
-        language_version: python3.6
-    -   id: check-yaml
-        language_version: python3.6
-    -   id: debug-statements
-        language_version: python3.6
-    -   id: name-tests-test
-        files: ^tests/.+\.py$
-        language_version: python3.6
-    -   id: flake8
-        language_version: python3.6
-    -   id: requirements-txt-fixer
-        language_version: python3.6
-    -   id: check-added-large-files
-        language_version: python3.6
-    -   id: check-byte-order-marker
-        language_version: python3.6
-    -   id: fix-encoding-pragma
-        language_version: python3.6
-        args: [--remove]
--   repo: https://github.com/asottile/reorder_python_imports.git
-    rev: v1.3.3
-    hooks:
-    -   id: reorder-python-imports
-        language_version: python3.6
-        args: [
-            --remove-import, 'from __future__ import absolute_import',
-            --remove-import, 'from __future__ import print_function',
-            --remove-import, 'from __future__ import unicode_literals',
-        ]
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.2
-    hooks:
-    -   id: autopep8
-        language_version: python3.6
+    - repo: https://github.com/pre-commit/pre-commit-hooks.git
+      rev: v2.0.0
+      hooks:
+          - id: trailing-whitespace
+            language_version: python3.8
+          - id: end-of-file-fixer
+            language_version: python3.8
+          - id: check-json
+            files: \.(jshintrc|json)$
+            language_version: python3.8
+          - id: check-yaml
+            language_version: python3.8
+          - id: debug-statements
+            language_version: python3.8
+          - id: name-tests-test
+            files: ^tests/.+\.py$
+            language_version: python3.8
+          - id: flake8
+            language_version: python3.8
+          - id: requirements-txt-fixer
+            language_version: python3.8
+          - id: check-added-large-files
+            language_version: python3.8
+          - id: check-byte-order-marker
+            language_version: python3.8
+          - id: fix-encoding-pragma
+            language_version: python3.8
+            args: [--remove]
+    - repo: https://github.com/asottile/reorder_python_imports.git
+      rev: v1.3.3
+      hooks:
+          - id: reorder-python-imports
+            language_version: python3.8
+            args:
+                [
+                    --remove-import,
+                    "from __future__ import absolute_import",
+                    --remove-import,
+                    "from __future__ import print_function",
+                    --remove-import,
+                    "from __future__ import unicode_literals",
+                ]
+    - repo: https://github.com/pre-commit/mirrors-autopep8
+      rev: v1.4.2
+      hooks:
+          - id: autopep8
+            language_version: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3
+    python: python3.8
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
     rev: v2.0.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Interfaces and shared infrastructure for generic task processing (also known as 
 ### Pre-requisites
 
 + [Docker](https://www.docker.com/get-docker)
-+ [Python 3.6](https://www.python.org/downloads/)
++ [Python 3.8](https://www.python.org/downloads/)
 + [Virtualenv](https://virtualenv.pypa.io/en/stable/installation/)
 
 ### Running examples

--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -17,10 +17,7 @@ RUN apt-get update -q && \
     && apt-get clean
 
 ARG PIP_INDEX_URL
-ARG NPM_CONFIG_REGISTRY
 ENV PIP_INDEX_URL=${PIP_INDEX_URL:-https://pypi.python.org/simple}
-ENV NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY:-https://npm.yelpcorp.com}
-
 # Get yarn
 # I'd use ubuntu yarn (yarnpkg) but https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1019291
 RUN wget --quiet -O - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -18,12 +18,6 @@ RUN apt-get update -q && \
 
 ARG PIP_INDEX_URL
 ENV PIP_INDEX_URL=${PIP_INDEX_URL:-https://pypi.python.org/simple}
-# Get yarn
-# I'd use ubuntu yarn (yarnpkg) but https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1019291
-RUN wget --quiet -O - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-RUN apt-get -q update && apt-get -q install -y --no-install-recommends yarn
-
 RUN pip3 install --index-url ${PIP_INDEX_URL} virtualenv==16.7.5
 
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd

--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -1,27 +1,33 @@
 FROM ubuntu:jammy
 
-ARG PIP_INDEX_URL
-ENV PIP_INDEX_URL=${PIP_INDEX_URL:-https://pypi.python.org/simple}
+RUN apt-get update -yq && \
+    apt-get install -yq \
+        # needed to add a ppa
+        software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa
 
 RUN apt-get update -q && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         software-properties-common \
         debhelper dpkg-dev gcc gdebi-core git help2man libffi-dev \
-        libssl-dev libsasl2-modules libyaml-dev pyflakes python3-dev python3-pip python3-pytest \
-        python-tox python-yaml wget zip zsh \
+        dh-virtualenv \
+        libssl-dev libsasl2-modules libyaml-dev pyflakes3 python3.8-dev python3.8-distutils python3-pip python3-pytest python3-http-parser\
+        tox python3-yaml wget zip zsh \
         openssh-server docker.io curl vim jq libsvn-dev \
     && apt-get clean
 
-RUN apt-get update -q && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.8 python3.8-dev python3.8-venv
-RUN wget https://bootstrap.pypa.io/pip/3.8/get-pip.py
-RUN python3.8 get-pip.py
-RUN ln -s /usr/bin/python3.8 /usr/local/bin/python3
+ARG PIP_INDEX_URL
+ARG NPM_CONFIG_REGISTRY
+ENV PIP_INDEX_URL=${PIP_INDEX_URL:-https://pypi.python.org/simple}
+ENV NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY:-https://npm.yelpcorp.com}
 
-RUN cd /tmp && \
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \
-    gdebi -n dh-virtualenv*.deb && \
-    rm dh-virtualenv_*.deb
+# Get yarn
+# I'd use ubuntu yarn (yarnpkg) but https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1019291
+RUN wget --quiet -O - https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+RUN apt-get -q update && apt-get -q install -y --no-install-recommends yarn
+
+RUN pip3 install --index-url ${PIP_INDEX_URL} virtualenv==16.7.5
 
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 RUN mkdir /var/run/sshd

--- a/examples/cluster/playground/Dockerfile
+++ b/examples/cluster/playground/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ARG PIP_INDEX_URL
 ENV PIP_INDEX_URL=${PIP_INDEX_URL:-https://pypi.python.org/simple}
@@ -13,10 +13,10 @@ RUN apt-get update -q && \
     && apt-get clean
 
 RUN apt-get update -q && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.6 python3.6-dev python3.6-venv
-RUN wget https://bootstrap.pypa.io/pip/3.6/get-pip.py
-RUN python3.6 get-pip.py
-RUN ln -s /usr/bin/python3.6 /usr/local/bin/python3
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.8 python3.8-dev python3.8-venv
+RUN wget https://bootstrap.pypa.io/pip/3.8/get-pip.py
+RUN python3.8 get-pip.py
+RUN ln -s /usr/bin/python3.8 /usr/local/bin/python3
 
 RUN cd /tmp && \
     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb && \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 # Testing dependencies
 docker-compose
 flake8
-# pin hypothesis since we don't want to switch to testing p37-only until we move tron to py37
-hypothesis==4.57.1
+hypothesis
 mock
 mypy
 pre-commit

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,6 @@ setup(
     install_requires=[
         # used for immutable data structures
         'pyrsistent',
-        # until we can drop py36, used for things like TypedDicts
-        'typing-extensions',
     ],
     extras_require={
         # We can add the Mesos specific dependencies here

--- a/task_processing/task_processor.py
+++ b/task_processing/task_processor.py
@@ -125,7 +125,7 @@ class TaskProcessor:
         else:
             raise ValueError(
                 '{0} provider not registered; available providers: {1}'.format(
-                    provider, self.registry.task_executors.keys().tolist()
+                    provider, list(self.registry.task_executors.keys())
                 )
             )
 

--- a/tests/unit/plugins/persistence/dynamo_persistence_test.py
+++ b/tests/unit/plugins/persistence/dynamo_persistence_test.py
@@ -1,5 +1,6 @@
 import pytest
 from hypothesis import given
+from hypothesis import HealthCheck
 from hypothesis import settings
 from hypothesis import strategies as st
 
@@ -23,6 +24,7 @@ def persister(mocker):
     return persister
 
 
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(x=st.dictionaries(
     keys=st.text(),
     values=st.decimals(allow_nan=False, allow_infinity=False)
@@ -32,16 +34,19 @@ def test_replaces_decimals_dict(x, persister):
         assert type(v) == float
 
 
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(x=st.decimals(allow_nan=False, allow_infinity=False))
 def test_replaces_decimals_decimal(x, persister):
     assert type(persister._replace_decimals(x)) is float
 
 
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(x=st.lists(st.decimals(allow_nan=False, allow_infinity=False)))
 def test_replaces_decimals_list(x, persister):
     assert all([type(v) == float for v in persister._replace_decimals(x)])
 
 
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(x=st.one_of(
     st.text(),
     st.booleans(),
@@ -73,7 +78,7 @@ events = st.builds(
 )
 
 
-@settings(max_examples=50)
+@settings(max_examples=50, suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(x=events)
 def test_event_to_item_timestamp(x, persister):
     res = persister._event_to_item(x)['M']
@@ -83,7 +88,7 @@ def test_event_to_item_timestamp(x, persister):
     assert 'M' in res['task_config'].keys()
 
 
-@settings(max_examples=50)
+@settings(max_examples=50, suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(x=events)
 def test_event_to_item_list(x, persister):
     res = persister._event_to_item(x)['M']

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py38
 
 [testenv]
 passenv = PIP_INDEX_URL
@@ -14,7 +14,7 @@ commands =
     pre-commit run --all-files
 
 [testenv:mesos]
-basepython = /usr/bin/python3.6
+basepython = /usr/bin/python3.8
 commands =
     pip install -e .[mesos_executor]
 
@@ -44,7 +44,7 @@ commands =
     run playground /src/itest
 
 [testenv:venv]
-basepython = /usr/bin/python3.6
+basepython = /usr/bin/python3.8
 envdir = venv
 commands =
     pip install -e .[mesos_executor,metrics,persistence,k8s]


### PR DESCRIPTION
The reason for adding `@settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))` was due to the warning below.

```
E       hypothesis.errors.FailedHealthCheck: Function-scoped fixture 'persister' used by 'tests/unit/plugins/persistence/dynamo_persistence_test.py::test_replaces_decimals_list'
E       
E       Function-scoped fixtures are not reset between examples generated by
E       `@given(...)`, which is often surprising and can cause subtle test bugs.
E       
E       If you were expecting the fixture to run separately for each generated example,
E       then unfortunately you will need to find a different way to achieve your goal
E       (e.g. using a similar context manager instead of a fixture).
E       
E       If you are confident that your test will work correctly even though the
E       fixture is not reset between generated examples, you can suppress this health
E       check to assure Hypothesis that you understand what you are doing.
E       
E       See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.function_scoped_fixture to the suppress_health_check settings for this test.

.tox/py38/lib/python3.8/site-packages/hypothesis/internal/healthcheck.py:27: FailedHealthCheck
```

Based on reading the tests and what they do I would assume that it's fine to re-use this fixture in multiple tests and suppress the warning. 