### PR TITLE
Support stdin and tty flags to support launching pods with commands like /bin/bash

### DIFF
--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -462,6 +462,9 @@ class KubernetesPodExecutor(TaskExecutor):
             ),
             volume_mounts=volume_mounts,
             ports=[V1ContainerPort(container_port=port) for port in task_config.ports],
+            stdin=task_config.stdin,
+            stdin_once=task_config.stdin_once,
+            tty=task_config.tty,
         )
 
     def run(self, task_config: KubernetesTaskConfig) -> Optional[str]:

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -383,6 +383,22 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         invariant=_valid_empty_volumes,
     )
 
+    stdin = field(
+        type=bool,
+        initial=False,
+        mandatory=False,
+    )
+    stdin_once = field(
+        type=bool,
+        initial=False,
+        mandatory=False,
+    )
+    tty = field(
+        type=bool,
+        initial=False,
+        mandatory=False,
+    )
+
     @property
     def pod_name(self) -> str:
         return get_sanitised_kubernetes_name(

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -119,6 +119,9 @@ def test_run(mock_get_node_affinity, k8s_executor):
         },
         service_account_name="testsa",
         ports=[8888],
+        stdin=True,
+        stdin_once=True,
+        tty=True,
     )
     expected_container = V1Container(
         image=task_config.image,
@@ -142,6 +145,9 @@ def test_run(mock_get_node_affinity, k8s_executor):
             read_only=True,
         )],
         ports=[V1ContainerPort(container_port=8888)],
+        stdin=True,
+        stdin_once=True,
+        tty=True,
     )
     expected_pod = V1Pod(
         metadata=V1ObjectMeta(


### PR DESCRIPTION
## Problem
If you try to launch a kubernetes pod with command=`/bin/bash` it will exit immediately. I am working out how to use `paasta local-run` to run an interactive pod on the cluster, and this is a first step in that direction.

## Solution
Plumb through the `stdin`, `stdin_once`, and `tty` flags for the [V1Container](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Container.md)