### PR TITLE
Adds reconciliation to pod tasks - threading

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,8 @@ mock
 mypy
 pre-commit
 pytest
+pytest-bdd
 pytest-cov
 pytest-mock
-pytest_bdd
 types-pyyaml
 types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,6 @@ pre-commit
 pytest
 pytest-cov
 pytest-mock
+pytest_bdd
 types-pyyaml
 types-requests

--- a/task_processing/plugins/kubernetes/kube_client.py
+++ b/task_processing/plugins/kubernetes/kube_client.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from http import HTTPStatus
+from typing import List
 from typing import Optional
 
 from kubernetes import client as kube_client
@@ -176,6 +177,11 @@ class KubeClient:
     def get_pod(
         self, namespace: str, pod_name: str, attempts: int = DEFAULT_ATTEMPTS,
     ) -> Optional[V1Pod]:
+        """
+        Wrapper around read_namespaced_pod() in the kubernetes clientlib that adds in
+        retrying on ApiExceptions.
+        Returns V1Pod on success, None otherwise.
+        """
         max_attempts = attempts
         while attempts:
             try:
@@ -201,3 +207,39 @@ class KubeClient:
                 raise
         logger.info(f"Ran out of retries attempting to fetch pod {pod_name}.")
         raise ExceededMaxAttempts(f'Retried fetching pod {pod_name} {max_attempts} times.')
+
+    def get_pods(
+        self, namespace: str, attempts: int = DEFAULT_ATTEMPTS,
+    ) -> Optional[List[V1Pod]]:
+        """
+        Wrapper around list_namespaced_pod() in the kubernetes clientlib that adds in
+        retrying on ApiExceptions.
+        Returns a list of V1Pod on success, None otherwise.
+        """
+        max_attempts = attempts
+        while attempts:
+            try:
+                pods = self.core.list_namespaced_pod(
+                    namespace=namespace,
+                ).items
+                return pods
+            except ApiException as e:
+                # Unknown pods throws ApiException w/ 404
+                if e.status == 404:
+                    logger.info(f"Found no pods in the namespace {namespace}.")
+                    return None
+                if not self.maybe_reload_on_exception(exception=e) and attempts:
+                    logger.debug(
+                        f"Failed to fetch pods in {namespace} due to unhandled API exception, "
+                        "retrying.",
+                        exc_info=True
+                    )
+                attempts -= 1
+            except Exception:
+                logger.exception(
+                    f"Failed to fetch pods in {namespace} due to unhandled exception."
+                )
+                raise
+        logger.info(f"Ran out of retries attempting to fetch pods in namespace {namespace}.")
+        raise ExceededMaxAttempts(
+            f'Retried fetching pods in namespace {namespace} {max_attempts} times.')

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -436,7 +436,7 @@ class KubernetesPodExecutor(TaskExecutor):
         logger.info(f'Waiting {REFRESH_EXECUTOR_STATE_THREAD_GRACE}s before doing work')
         sleep(REFRESH_EXECUTOR_STATE_THREAD_GRACE)
         logger.debug("Starting Pod task config reconciliation.")
-        while not self.stopping:
+        while not self.is_stopping:
             try:
                 pods = self.kube_client.get_pods(namespace=self.namespace)
             except Exception:
@@ -675,3 +675,11 @@ class KubernetesPodExecutor(TaskExecutor):
 
     def get_event_queue(self) -> "Queue[Event]":
         return self.event_queue
+
+    @property
+    def is_stopping(self):
+        return self.stopping
+
+    @is_stopping.setter
+    def is_stopping(self, val):
+        self.stopping = val

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -195,11 +195,14 @@ class KubernetesPodExecutor(TaskExecutor):
         Called during reconciliation task loop in order to filter the task_configs/pods
         that are in task_metadata.
         """
+        v1pods = {pod.metadata.name: pod for pod in pods}
         task_config_pods = []
-        for pod in pods:
-            if pod.metadata.name in self.task_metadata:
-                task_config_pod = (self.task_metadata[pod.metadata.name].task_config, pod)
+
+        for pod_name, task_metadata in self.task_metadata.items():
+            if pod_name in v1pods:
+                task_config_pod = (task_metadata.task_config, v1pods[pod_name])
                 task_config_pods.append(task_config_pod)
+
         return task_config_pods
 
     def __handle_deleted_pod_event(self, event: PodEvent) -> None:
@@ -467,7 +470,6 @@ class KubernetesPodExecutor(TaskExecutor):
                 logger.exception(
                     f"Hit an exception attempting to fetch pods in namespace {self.namespace}")
                 pods = None
-                continue
 
             if pods is not None:
                 # we've previously bulk-fetched all the pods running in the target

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -222,7 +222,9 @@ class KubernetesPodExecutor(TaskExecutor):
         }
 
         for task_config, pod in task_configs_pods:
-            # If the pod is not returned then we must set the task_metadata to lost state - if k8s no longer knows about this pod/task, then there's no way for us to figure out it's final state in an automated fashion
+            # If the pod is not returned then we must set the task_metadata to lost state
+            # if k8s no longer knows about this pod/task, then there's no way for us to
+            # figure out it's final state in an automated fashion
             if pod is None:
                 task_configs_pods_to_reconcile.append((task_config, pod))
                 continue

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -206,7 +206,7 @@ class KubernetesPodExecutor(TaskExecutor):
 
     def _filter_task_configs_pods_to_reconcile(
         self,
-        task_configs_pods: List[Tuple[KubernetesTaskConfig, V1Pod]]
+        task_configs_pods: List[Tuple[KubernetesTaskConfig, Optional[V1Pod]]]
     ) -> List[Tuple[KubernetesTaskConfig, Optional[V1Pod]]]:
         """
         Called during reconciliation task loop in order to filter the task_configs/pods

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -226,13 +226,19 @@ class KubernetesPodExecutor(TaskExecutor):
             for task_config, pod in task_configs_pods:
                 pod_name = pod.metadata.name
                 pod_phase = pod.status.phase
-                task_metadata_state = self.task_metadata[pod_name].task_state
+                task_metadata = self.task_metadata[pod_name]
+                task_metadata_state = task_metadata.task_state
                 if pod_phase not in phase_task_state_map:
                     logger.debug(
                         f"Got a MODIFIED event for {pod_name} for unhandled phase: "
                         f"{pod_phase} - ignoring."
                     )
                 if phase_task_state_map[pod_phase] is not task_metadata_state:
+                    logger.debug(
+                        f"Mismatched event found for {pod_name} during reconciliation."
+                        f"pod_phase: {pod_phase} vs task_metadata_state: {task_metadata_state}"
+                        f"task_metadata{task_metadata}"
+                    )
                     task_configs_pods_to_reconcile.append((task_config, pod))
 
         return task_configs_pods_to_reconcile

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -222,7 +222,7 @@ class KubernetesPodExecutor(TaskExecutor):
         }
 
         for task_config, pod in task_configs_pods:
-            # If the pod is not returned then we must set the task_metadata to lost state
+            # If the pod is not returned then we must set the task_metadata to lost state - if k8s no longer knows about this pod/task, then there's no way for us to figure out it's final state in an automated fashion
             if pod is None:
                 task_configs_pods_to_reconcile.append((task_config, pod))
                 continue

--- a/task_processing/utils.py
+++ b/task_processing/utils.py
@@ -39,13 +39,3 @@ def get_cluster_master_by_proxy(
     else:
         addr_info = services[proxy_name]
         return addr_info['host'] + ':' + str(addr_info['port'])
-
-
-def strtobool(s: str) -> bool:
-    truevals = ("yes", "y", "on", "true", "t", "1")
-    falsevals = ("no", "n", "off", "false", "f", "0")
-    if s.lower() in truevals:
-        return True
-    if s.lower() in falsevals:
-        return False
-    raise ValueError(f"invalid truth value: {s}")

--- a/task_processing/utils.py
+++ b/task_processing/utils.py
@@ -39,3 +39,13 @@ def get_cluster_master_by_proxy(
     else:
         addr_info = services[proxy_name]
         return addr_info['host'] + ':' + str(addr_info['port'])
+
+
+def strtobool(s: str) -> bool:
+    truevals = ("yes", "y", "on", "true", "t", "1")
+    falsevals = ("no", "n", "off", "false", "f", "0")
+    if s.lower() in truevals:
+        return True
+    if s.lower() in falsevals:
+        return False
+    raise ValueError(f"invalid truth value: {s}")

--- a/tests/unit/plugins/kubernetes/kube_client_test.py
+++ b/tests/unit/plugins/kubernetes/kube_client_test.py
@@ -111,3 +111,22 @@ def test_KubeClient_get_pod():
     mock_kube_client.CoreV1Api().read_namespaced_pod.assert_called_once_with(
         namespace='ns', name='pod-name'
     )
+
+
+def test_KubeClient_get_pods():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client, mock.patch.dict(
+        os.environ, {"KUBECONFIG": "/another/kube/config.conf"}
+    ):
+        mock_config_path = "/OVERRIDE.conf"
+        mock_kube_client.CoreV1Api().list_namespaced_pod.return_value = mock.Mock()
+        client = KubeClient(kubeconfig_path=mock_config_path)
+        client.get_pods(namespace='ns', attempts=1)
+    mock_kube_client.CoreV1Api().list_namespaced_pod.assert_called_once_with(
+        namespace='ns'
+    )

--- a/tests/unit/plugins/kubernetes/kube_client_test.py
+++ b/tests/unit/plugins/kubernetes/kube_client_test.py
@@ -113,6 +113,39 @@ def test_KubeClient_get_pod():
     )
 
 
+def test_KubeClient_get_pods_too_many_failures():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client, mock.patch.dict(
+        os.environ, {"KUBECONFIG": "/another/kube/config.conf"}
+    ), pytest.raises(ExceededMaxAttempts):
+        mock_config_path = "/OVERRIDE.conf"
+        mock_kube_client.CoreV1Api().list_namespaced_pod.side_effect = [ApiException, ApiException]
+        client = KubeClient(kubeconfig_path=mock_config_path)
+        client.get_pods(namespace='ns', attempts=2)
+    assert mock_kube_client.CoreV1Api().list_namespaced_pod.call_count == 2
+
+
+def test_KubeClient_get_pods_unknown_exception():
+    with mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",
+        autospec=True
+    ), mock.patch(
+        "task_processing.plugins.kubernetes.kube_client.kube_client",
+        autospec=True
+    ) as mock_kube_client, mock.patch.dict(
+        os.environ, {"KUBECONFIG": "/another/kube/config.conf"}
+    ), pytest.raises(Exception):
+        mock_config_path = "/OVERRIDE.conf"
+        mock_kube_client.CoreV1Api().list_namespaced_pod.side_effect = [Exception]
+        client = KubeClient(kubeconfig_path=mock_config_path)
+        client.get_pods(namespace='ns', attempts=2)
+
+
 def test_KubeClient_get_pods():
     with mock.patch(
         "task_processing.plugins.kubernetes.kube_client.kube_config.load_kube_config",

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -355,11 +355,16 @@ def test_reconcile_task_loop_reconcile_existing_pods_only(k8s_executor, mock_tas
         k8s_executor,
         "kube_client",
         autospec=True
-    ) as mock_kube_client:
+    ) as mock_kube_client, mock.patch(
+        "task_processing.plugins.kubernetes.kubernetes_pod_executor.KubernetesPodExecutor.is_stopping",  # noqa
+        new_callable=mock.PropertyMock,
+        side_effect=[False, True]
+    ):
         mock_kube_client.get_pods.return_value = mock_pods
         k8s_executor._reconcile_task_loop()
 
-    assert len(mock_reconcile_task.assert_called()) == 3
+    mock_reconcile_task.assert_called()
+    assert mock_reconcile_task.call_count == 3
 
 
 def test_process_event_enqueues_task_processing_events_deleted(

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -351,7 +351,7 @@ def test__filter_task_configs_in_pods_existing_pods_only(k8s_executor, mock_task
         autospec=True
     ) as mock_kube_client:
         mock_kube_client.get_pods.return_value = mock_pods
-        task_config_pods = k8s_executor._filter_task_configs_in_pods(mock_pods)
+        task_config_pods = k8s_executor._group_pod_task_configs(mock_pods)
 
     assert len(task_config_pods) == 3
 
@@ -382,7 +382,7 @@ def test__filter_task_configs_pods_to_reconcile_running_state(k8s_executor, mock
         autospec=True
     ) as mock_kube_client:
         mock_kube_client.get_pods.return_value = mock_pods
-        task_config_pods = k8s_executor._filter_task_configs_in_pods(mock_pods)
+        task_config_pods = k8s_executor._group_pod_task_configs(mock_pods)
         task_config_pods_filtered = k8s_executor._filter_task_configs_pods_to_reconcile(
             task_config_pods)
 

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -36,7 +36,10 @@ def k8s_executor(mock_Thread):
         "task_processing.plugins.kubernetes.kube_client.kube_client",
         autospec=True
     ), mock.patch.dict(os.environ, {"KUBECONFIG": "/this/doesnt/exist.conf"}):
-        executor = KubernetesPodExecutor(namespace="task_processing_tests")
+        executor = KubernetesPodExecutor(namespace="task_processing_tests",
+                                         refresh_reconciliation_thread_grace=1,
+                                         refresh_reconciliation_thread_interval=1,
+                                         enable_reconciliation=True)
         yield executor
         executor.stop()
 
@@ -318,14 +321,6 @@ def test_pending_event_processing_loop_processes_remaining_events_after_stop(k8s
     assert k8s_executor.pending_events.qsize() == 0
 
 
-@mock.patch(
-    "task_processing.plugins.kubernetes.kubernetes_pod_executor.REFRESH_EXECUTOR_STATE_THREAD_GRACE",  # noqa
-    1,
-)
-@mock.patch(
-    "task_processing.plugins.kubernetes.kubernetes_pod_executor.REFRESH_EXECUTOR_STATE_THREAD_INTERVAL",  # noqa
-    1,
-)
 def test_reconcile_task_loop_reconcile_existing_pods_only(k8s_executor, mock_task_configs):
     mock_pods = []
     test_phases = ['Unknown', 'Succeeded', 'Failed', 'Running']


### PR DESCRIPTION
This is a threading approach to adding reconciliation to pod tasks.

Context: We're seeing Kubernetes events being missed by task_processing after upgrading Tron to Python 3.8. We're have not identified the root cause and are unable to reproduce this in our stage environment. However by performing reconciliation on the Kubernetes events we can be sure that events that are missed will be able to reconcile to its true state.

This is a similar approach to #203, but instead of multiprocessing we are using threading.