### PR TITLE
Add support for overriding resource requests

### DIFF
--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -304,6 +304,17 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         initial=10.0,
         factory=float,
         invariant=lambda d: (d > 0, 'disk > 0'))
+
+    request_cpus = field(
+        type=float,
+        factory=float)
+    request_memory = field(
+        type=float,
+        factory=float)
+    request_disk = field(
+        type=float,
+        factory=float)
+
     environment = field(
         type=PMap if not TYPE_CHECKING else PMap[str, str],
         initial=m(),

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -2,6 +2,7 @@ import re
 import secrets
 import string
 from itertools import chain
+from typing import Any
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
@@ -301,6 +302,7 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
     cpus_request = field(
         type=(float, type(None)),
         factory=_float_or_none,
+        invariant=lambda c: (c is None or c > 0, 'cpus_request > 0'),
         initial=None)
 
     memory = field(
@@ -311,6 +313,7 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
     memory_request = field(
         type=(float, type(None)),
         factory=_float_or_none,
+        invariant=lambda m: (m is None or m >= 32, 'mem_request >= 32'),
         initial=None)
 
     disk = field(

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -238,6 +238,12 @@ def _valid_service_account_name(
     )
 
 
+def _float_or_none(str: Optional[str]) -> Optional[float]:
+    if str:
+        return float(str)
+    return None
+
+
 class KubernetesTaskConfig(DefaultTaskConfigInterface):
     def __invariant__(self) -> Tuple[Tuple[bool, str], ...]:
         valid_length = len(self.pod_name) <= MAX_POD_NAME_LENGTH
@@ -296,6 +302,7 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         invariant=lambda c: (c > 0, 'cpus > 0'))
     cpus_request = field(
         type=(float, type(None)),
+        factory=_float_or_none,
         initial=None)
 
     memory = field(
@@ -305,6 +312,7 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         invariant=lambda m: (m >= 32, 'mem is >= 32'))
     memory_request = field(
         type=(float, type(None)),
+        factory=_float_or_none,
         initial=None)
 
     disk = field(

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -294,26 +294,24 @@ class KubernetesTaskConfig(DefaultTaskConfigInterface):
         initial=0.1,
         factory=float,
         invariant=lambda c: (c > 0, 'cpus > 0'))
+    cpus_request = field(
+        type=(float, type(None)),
+        initial=None)
+
     memory = field(
         type=float,
         initial=128.0,
         factory=float,
         invariant=lambda m: (m >= 32, 'mem is >= 32'))
+    memory_request = field(
+        type=(float, type(None)),
+        initial=None)
+
     disk = field(
         type=float,
         initial=10.0,
         factory=float,
         invariant=lambda d: (d > 0, 'disk > 0'))
-
-    request_cpus = field(
-        type=float,
-        factory=float)
-    request_memory = field(
-        type=float,
-        factory=float)
-    request_disk = field(
-        type=float,
-        factory=float)
 
     environment = field(
         type=PMap if not TYPE_CHECKING else PMap[str, str],

--- a/task_processing/plugins/kubernetes/task_config.py
+++ b/task_processing/plugins/kubernetes/task_config.py
@@ -238,10 +238,8 @@ def _valid_service_account_name(
     )
 
 
-def _float_or_none(str: Optional[str]) -> Optional[float]:
-    if str:
-        return float(str)
-    return None
+def _float_or_none(val: Any) -> Optional[float]:
+    return float(val) if val is not None else None
 
 
 class KubernetesTaskConfig(DefaultTaskConfigInterface):

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -107,8 +107,8 @@ def test_run(mock_get_node_affinity, k8s_executor):
         command="fake_command",
         cpus=1,
         memory=1024,
+        memory_request=768.0,
         disk=1024,
-        request_memory=768,
         volumes=[{"host_path": "/a", "container_path": "/b", "mode": "RO"}],
         node_selectors={"hello": "world"},
         node_affinities=[dict(key="a_label", operator="In", value=[])],
@@ -139,6 +139,7 @@ def test_run(mock_get_node_affinity, k8s_executor):
                 "ephemeral-storage": "1024.0Mi",
             },
             requests={
+                "cpu": None,
                 "memory": "768.0Mi",
             }
         ),

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -16,6 +16,7 @@ from kubernetes.client import V1ResourceRequirements
 from kubernetes.client import V1SecurityContext
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
+from pyrsistent import InvariantException
 from pyrsistent import pmap
 from pyrsistent import pvector
 from pyrsistent import v
@@ -190,6 +191,30 @@ def test_run(mock_get_node_affinity, k8s_executor):
     assert mock_get_node_affinity.call_args_list == [
         mock.call(pvector([dict(key="a_label", operator="In", value=[])])),
     ]
+
+
+def test_run_bad_memory_request(k8s_executor):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="fake_task_name",
+            uuid="fake_id",
+            image="fake_docker_image",
+            command="fake_command",
+            memory=1024,
+            memory_request=24,
+        )
+
+
+def test_run_bad_cpu_request(k8s_executor):
+    with pytest.raises(InvariantException):
+        KubernetesTaskConfig(
+            name="fake_task_name",
+            uuid="fake_id",
+            image="fake_docker_image",
+            command="fake_command",
+            cpus=1.0,
+            cpus_request="0.0",
+        )
 
 
 def test_run_failed_exception(k8s_executor):

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -107,7 +107,7 @@ def test_run(mock_get_node_affinity, k8s_executor):
         command="fake_command",
         cpus=1,
         memory=1024,
-        memory_request=768.0,
+        memory_request=768,
         disk=1024,
         volumes=[{"host_path": "/a", "container_path": "/b", "mode": "RO"}],
         node_selectors={"hello": "world"},

--- a/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_pod_executor_test.py
@@ -108,6 +108,7 @@ def test_run(mock_get_node_affinity, k8s_executor):
         cpus=1,
         memory=1024,
         disk=1024,
+        request_memory=768,
         volumes=[{"host_path": "/a", "container_path": "/b", "mode": "RO"}],
         node_selectors={"hello": "world"},
         node_affinities=[dict(key="a_label", operator="In", value=[])],
@@ -136,6 +137,9 @@ def test_run(mock_get_node_affinity, k8s_executor):
                 "cpu": 1.0,
                 "memory": "1024.0Mi",
                 "ephemeral-storage": "1024.0Mi",
+            },
+            requests={
+                "memory": "768.0Mi",
             }
         ),
         env=[],


### PR DESCRIPTION
Resource requests are currently not explicitly set - this results in k8s setting
the memory/cpu/disk requests to the same value as the limit.

For the most part, this is desired behaviour at Yelp as the main consumer of this
library is Tron and we don't expect our batches to need to "burst" any of these
resources. Additionally, we generally want to signal to k8s that our batches shouldn't
be killed if there are other (more interrupt-tolerant) workloads on an overloaded
node by defaulting the QoS class for any task_proc-created Pods to `Guaranteed`
precisely by setting `requests = limits`.

However, one of our other large task_proc workloads (Jolt) would like to have 
control over the requests as their workload runs in an isolated pool and cannot (at
least at the moment) be easily right-sized for optimal bin-packing/resource usage.

But, given that Jolt runs in its own pool, we can be a little cheeky and set lower
requests to pack Pods a little tighter since Jolt *is* quite interrupt-tolerant and
as such is resilient to its Pods getting killed due to node resource pressure (which
should be pretty rare in any case given the current usage patterns).