### PR TITLE
Add typing-extensions as a k8s-specific dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
         "mesos_executor": ["addict", "pymesos>=0.2.14", "requests"],
         "metrics": ["yelp-meteorite"],
         "persistence": ["boto3"],
-        "k8s": ["kubernetes"],
+        "k8s": ["kubernetes", "typing-extensions"],
     },
 )


### PR DESCRIPTION
Let's fix the dep-problem here rather than patching downstream :) 
context: https://yelp.slack.com/archives/C048HCBDD0U/p1686322172245599