### PR TITLE
Reusing global Configuration() object in k8s client models instances

### DIFF
--- a/task_processing/plugins/kubernetes/kube_client.py
+++ b/task_processing/plugins/kubernetes/kube_client.py
@@ -5,10 +5,12 @@ from typing import Optional
 
 from kubernetes import client as kube_client
 from kubernetes import config as kube_config
+from kubernetes.client.configuration import Configuration
 from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models.v1_pod import V1Pod
 
 logger = logging.getLogger(__name__)
+K8S_API_CLIENT_CONFIGURATION = Configuration.get_default_copy()
 
 DEFAULT_ATTEMPTS = 2
 
@@ -39,7 +41,9 @@ class KubeClient:
         self.initialize_api_client()
 
     def initialize_api_client(self) -> None:
-        self.api_client = kube_client.ApiClient()
+        self.api_client = kube_client.ApiClient(
+            configuration=K8S_API_CLIENT_CONFIGURATION
+        )
         self.api_client.user_agent = self.user_agent
 
         # any Kubernetes APIs that we use should be added as members here (much like as we

--- a/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
+++ b/task_processing/plugins/kubernetes/kubernetes_pod_executor.py
@@ -25,6 +25,7 @@ from pyrsistent.typing import PMap
 from task_processing.interfaces import TaskExecutor
 from task_processing.interfaces.event import Event
 from task_processing.interfaces.event import task_event
+from task_processing.plugins.kubernetes.kube_client import K8S_API_CLIENT_CONFIGURATION
 from task_processing.plugins.kubernetes.kube_client import KubeClient
 from task_processing.plugins.kubernetes.task_config import KubernetesTaskConfig
 from task_processing.plugins.kubernetes.task_metadata import KubernetesTaskMetadata
@@ -44,7 +45,6 @@ from task_processing.plugins.kubernetes.utils import get_pod_volumes
 from task_processing.plugins.kubernetes.utils import get_sanitised_kubernetes_name
 
 logger = logging.getLogger(__name__)
-k8s_client_configuration = Configuration.get_default_copy()
 
 POD_WATCH_THREAD_JOIN_TIMEOUT_S = 1.0
 POD_EVENT_THREAD_JOIN_TIMEOUT_S = 1.0
@@ -454,7 +454,7 @@ class KubernetesPodExecutor(TaskExecutor):
             security_context = V1SecurityContext(
                 capabilities=capabilities,
                 privileged=task_config.privileged,
-                local_vars_configuration=k8s_client_configuration,
+                local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
             )
 
         requests = {}
@@ -475,7 +475,7 @@ class KubernetesPodExecutor(TaskExecutor):
             limits=limits,
             # None is the default for an empty V1ResourceRequirements
             requests=requests if requests else None,
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
 
         return V1Container(
@@ -494,14 +494,14 @@ class KubernetesPodExecutor(TaskExecutor):
             ports=[
                 V1ContainerPort(
                     container_port=port,
-                    local_vars_configuration=k8s_client_configuration,
+                    local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
                 )
                 for port in task_config.ports
             ],
             stdin=task_config.stdin,
             stdin_once=task_config.stdin_once,
             tty=task_config.tty,
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
 
     def run(self, task_config: KubernetesTaskConfig) -> Optional[str]:
@@ -532,7 +532,7 @@ class KubernetesPodExecutor(TaskExecutor):
                     namespace=self.namespace,
                     labels=dict(task_config.labels),
                     annotations=dict(task_config.annotations),
-                    local_vars_configuration=k8s_client_configuration,
+                    local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
                 ),
                 spec=V1PodSpec(
                     restart_policy=task_config.restart_policy,
@@ -541,7 +541,7 @@ class KubernetesPodExecutor(TaskExecutor):
                     node_selector=dict(task_config.node_selectors),
                     affinity=V1Affinity(
                         node_affinity=get_node_affinity(task_config.node_affinities),
-                        local_vars_configuration=k8s_client_configuration,
+                        local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
                     ),
                     # we're hardcoding this as Default as this is what we generally use
                     # internally - until we have a usecase for something that needs one
@@ -551,10 +551,10 @@ class KubernetesPodExecutor(TaskExecutor):
                     share_process_namespace=True,
                     security_context=V1PodSecurityContext(
                         fs_group=task_config.fs_group,
-                        local_vars_configuration=k8s_client_configuration,
+                        local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
                     ),
                     service_account_name=task_config.service_account_name,
-                    local_vars_configuration=k8s_client_configuration,
+                    local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
                 ),
             )
         except Exception:

--- a/task_processing/plugins/kubernetes/utils.py
+++ b/task_processing/plugins/kubernetes/utils.py
@@ -24,6 +24,7 @@ from kubernetes.client.configuration import Configuration
 from pyrsistent.typing import PMap
 from pyrsistent.typing import PVector
 
+from task_processing.plugins.kubernetes.kube_client import K8S_API_CLIENT_CONFIGURATION
 from task_processing.plugins.kubernetes.types import NodeAffinityOperator
 
 if TYPE_CHECKING:
@@ -35,7 +36,6 @@ if TYPE_CHECKING:
     from task_processing.plugins.kubernetes.types import ObjectFieldSelectorSource
 
 logger = logging.getLogger(__name__)
-k8s_client_configuration = Configuration.get_default_copy()
 
 
 def get_capabilities_for_capability_changes(
@@ -73,7 +73,7 @@ def get_kubernetes_env_vars(
     """
     env_vars = [
         V1EnvVar(
-            name=key, value=value, local_vars_configuration=k8s_client_configuration
+            name=key, value=value, local_vars_configuration=K8S_API_CLIENT_CONFIGURATION
         )
         for key, value in environment.items()
         if key not in secret_environment.keys()
@@ -87,11 +87,11 @@ def get_kubernetes_env_vars(
                     name=value["secret_name"],
                     key=value["key"],
                     optional=False,
-                    local_vars_configuration=k8s_client_configuration,
+                    local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
                 ),
-                local_vars_configuration=k8s_client_configuration,
+                local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
             ),
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
         for key, value in secret_environment.items()
     ]
@@ -102,11 +102,11 @@ def get_kubernetes_env_vars(
             value_from=V1EnvVarSource(
                 field_ref=V1ObjectFieldSelector(
                     field_path=value["field_path"],
-                    local_vars_configuration=k8s_client_configuration,
+                    local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
                 ),
-                local_vars_configuration=k8s_client_configuration,
+                local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
             ),
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
         for key, value in field_selector_environment.items()
     ]
@@ -183,7 +183,7 @@ def get_kubernetes_volume_mounts(
                 f"host--{volume['host_path']}", length_limit=63
             ),
             read_only=volume.get("mode", "RO") == "RO",
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
         for volume in volumes
     ]
@@ -203,7 +203,7 @@ def get_kubernetes_secret_volume_mounts(
                 f"secret--{volume['secret_name']}", length_limit=63
             ),
             read_only=True,
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
         for volume in volumes
     ]
@@ -229,7 +229,7 @@ def _get_items_for_secret_volume(
                 key=item["key"],
                 mode=mode_to_int(item.get("mode")),
                 path=item["path"],
-                local_vars_configuration=k8s_client_configuration,
+                local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
             )
             for item in secret_volume["items"]
         ]
@@ -262,7 +262,7 @@ def get_pod_secret_volumes(secret_volumes: PVector["SecretVolume"]) -> List[V1Vo
                 secret_name=volume["secret_volume_name"],
                 default_mode=mode_to_int(volume.get("default_mode")),
                 items=_get_items_for_secret_volume(volume),
-                local_vars_configuration=k8s_client_configuration,
+                local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
             ),
         )
         for name, volume in unique_volumes.items()
@@ -285,10 +285,10 @@ def get_pod_volumes(volumes: PVector["DockerVolume"]) -> List[V1Volume]:
         V1Volume(
             host_path=V1HostPathVolumeSource(
                 path=volume["host_path"],
-                local_vars_configuration=k8s_client_configuration,
+                local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
             ),
             name=name,
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
         for name, volume in unique_volumes.items()
     ]
@@ -307,7 +307,7 @@ def get_kubernetes_empty_volume_mounts(
             name=get_sanitised_volume_name(
                 f"empty--{volume['container_path']}", length_limit=63
             ),
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
         for volume in empty_volumes
     ]
@@ -332,7 +332,7 @@ def get_pod_empty_volumes(empty_volumes: PVector["EmptyVolume"]) -> List[V1Volum
                 medium=volume["medium"],
                 size_limit=volume["size"],
             ),
-            local_vars_configuration=k8s_client_configuration,
+            local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
         )
         for name, volume in unique_volumes.items()
     ]
@@ -359,7 +359,7 @@ def get_node_affinity(affinities: PVector["NodeAffinity"]) -> Optional[V1NodeAff
                 key=str(aff["key"]),
                 operator=op,
                 values=val,
-                local_vars_configuration=k8s_client_configuration,
+                local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
             )
         )
 
@@ -373,9 +373,9 @@ def get_node_affinity(affinities: PVector["NodeAffinity"]) -> Optional[V1NodeAff
             node_selector_terms=[
                 V1NodeSelectorTerm(
                     match_expressions=match_expressions,
-                    local_vars_configuration=k8s_client_configuration,
+                    local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
                 )
             ],
         ),
-        local_vars_configuration=k8s_client_configuration,
+        local_vars_configuration=K8S_API_CLIENT_CONFIGURATION,
     )


### PR DESCRIPTION
Reusing global Configuration() object in k8s client models instances to avoid calling setLevel which will do a potentially expensive cache clear