### PR TITLE
Adding multiple processes to task_proc - TRON-2192

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 import threading
+import multiprocessing
 
 import mock
 import pytest
@@ -14,3 +15,8 @@ def mock_sleep():
 def mock_Thread():
     with mock.patch.object(threading, "Thread") as mock_Thread:
         yield mock_Thread
+
+@pytest.fixture
+def mock_Process():
+    with mock.patch.object(multiprocessing, 'Process') as mock_Process:
+        yield mock_Process


### PR DESCRIPTION
This draft PR is still in progress. The intent is to separate the ``_pending_event_processing_loop`` and ``_pod_event_watch_loop`` into their own process  introducing multi-processing in task_proc and thus tron.

### Testing
is in-progress