### PR TITLE
TRON-2333: Fix pod names ending in .--xxxx

### DIFF
--- a/task_processing/plugins/kubernetes/utils.py
+++ b/task_processing/plugins/kubernetes/utils.py
@@ -153,8 +153,10 @@ def get_sanitised_kubernetes_name(
         # the part of the name that does fit in the limit in order to replace them with
         # -- (2 characters) and then a 4 character hash (which should help ensure uniqueness
         # after truncation).
+        truncated_name = name[0 : length_limit - 6]
         name = (
-            name[0 : length_limit - 6]
+            # Avoid splitting the suffix into a subdomain as it would not meet RFC1123 requirements
+            truncated_name.rstrip(".")
             + "--"
             + hashlib.md5(name.encode("ascii")).hexdigest()[:4]
         )

--- a/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
+++ b/tests/unit/plugins/kubernetes/kubernetes_utils_test.py
@@ -62,28 +62,39 @@ def test_get_capabilities_for_capability_changes(cap_add, cap_drop, expected):
 
 
 @pytest.mark.parametrize(
-    "name,expected_name",
+    "name,expected_name,length_limit",
     (
         (
             "hello_world",
             "hello--world",
+            0,
         ),
         (
             "hello_world",
             "hello--world",
+            0,
         ),
         (
             "--hello_world",
             "underscore-hello--world",
+            0,
         ),
         (
             "TeSt",
             "test",
+            0,
+        ),
+        (
+            "hello--world.123.run",
+            "hello--world--cf28",
+            19,
         ),
     ),
 )
-def test_get_sanitised_kubernetes_name(name, expected_name):
-    assert get_sanitised_kubernetes_name(name) == expected_name
+def test_get_sanitised_kubernetes_name(name, expected_name, length_limit):
+    assert (
+        get_sanitised_kubernetes_name(name, length_limit=length_limit) == expected_name
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There was an edge case where sanitized pod names ending up with .<6 characters> would then get truncated to something like `.--<4 random chars>` due to our truncation logic in `get_sanitised_kubernetes_name`. 

However `.--aaaa` is not valid in a pod name as each section between `.`s must start with an alphanumeric character.

We saw errors such as the following when this case was hit:
```
{"reason":"FieldValueInvalid","message":"Invalid value: \"some-long-pod-name.--9b3a\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and
must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')","field":"metadata.name"}
```

## Solution
Before we try to add our truncation suffix, we simply strip any trailing `.` in our truncated name. This yields a pod name 1 character less than expected, but ensures pod name formats will continue to match previous expectations. 

I also did not strip any further characters as `.` was the most important one that would cause validation to fail.

## Verification
with the new test in place but using the old `get_sanitised_kubernetes_name`, the test fails as expected, with the non-RFC1123-compliant result:
```
E       AssertionError: assert 'hello--world.--cf28' == 'hello--world--cf28'
E
E         - hello--world--cf28
E         + hello--world.--cf28
E         ?             +
```

